### PR TITLE
Support for asset freeze/un-freeze transactions

### DIFF
--- a/algosdk/constants.py
+++ b/algosdk/constants.py
@@ -22,6 +22,8 @@ keyreg_txn = "keyreg"
 """str: indicates a key registration transaction"""
 assetconfig_txn = "acfg"
 """str: indicates an asset configuration transaction"""
+assetfreeze_txn = "afrz"
+"""str: indicates an asset freeze transaction"""
 
 
 # note field types

--- a/algosdk/encoding.py
+++ b/algosdk/encoding.py
@@ -53,6 +53,8 @@ def msgpack_decode(enc):
             return transaction.AssetConfigTxn.undictify(decoded)
         elif decoded["type"] == constants.assetfreeze_txn:
             return transaction.AssetFreezeTxn.undictify(decoded)
+        elif decoded["type"] == constants.assettransfer_txn:
+            return transaction.AssetTransferTxn.undictify(decoded)
     if "msig" in decoded:
         return transaction.MultisigTransaction.undictify(decoded)
     if "txn" in decoded:

--- a/algosdk/encoding.py
+++ b/algosdk/encoding.py
@@ -51,6 +51,8 @@ def msgpack_decode(enc):
             return transaction.KeyregTxn.undictify(decoded)
         elif decoded["type"] == constants.assetconfig_txn:
             return transaction.AssetConfigTxn.undictify(decoded)
+        elif decoded["type"] == constants.assetfreeze_txn:
+            return transaction.AssetFreezeTxn.undictify(decoded)
     if "msig" in decoded:
         return transaction.MultisigTransaction.undictify(decoded)
     if "txn" in decoded:

--- a/algosdk/transaction.py
+++ b/algosdk/transaction.py
@@ -100,7 +100,7 @@ class PaymentTxn(Transaction):
         amt (int): amount in microAlgos to be sent
         close_remainder_to (str, optional): if nonempty, account will be closed
             and remaining algos will be sent to this address
-        note (bytes, optional): encoded NoteField object
+        note (bytes, optional): arbitrary optional bytes
         gen (str, optional): genesis_id
         flat_fee (bool): whether the specified fee is a flat fee
 
@@ -206,7 +206,7 @@ class KeyregTxn(Transaction):
         votefst (int): first round to vote
         votelst (int): last round to vote
         votekd (int): vote key dilution
-        note (bytes, optional): encoded NoteField object
+        note (bytes, optional): arbitrary optional bytes
         gen (str): genesis_id
         flat_fee (bool): whether the specified fee is a flat fee
 
@@ -334,7 +334,7 @@ class AssetConfigTxn(Transaction):
             holdings of this asset
         clawback (str, optional): account allowed take units of this asset
             from any account
-        note (bytes, optional): encoded NoteField object
+        note (bytes, optional): arbitrary optional bytes
         gen (str, optional): genesis_id
         flat_fee (bool): whether the specified fee is a flat fee
 
@@ -511,7 +511,7 @@ class AssetFreezeTransaction(Transaction):
         index (int): index of the asset
         target (str): address having its assets frozen or unfrozen
         new_freeze_state (bool): true if the assets should be frozen, false if they should be transferrable
-        note (bytes, optional): encoded NoteField object
+        note (bytes, optional): arbitrary optional bytes
         gen (str, optional): genesis_id
         flat_fee (bool): whether the specified fee is a flat fee
 

--- a/algosdk/transaction.py
+++ b/algosdk/transaction.py
@@ -496,7 +496,7 @@ class AssetConfigTxn(Transaction):
                 self.clawback == other.clawback and
                 self.type == other.type)
 
-class AssetFreezeTransaction(Transaction):
+class AssetFreezeTxn(Transaction):
     """
     Represents a transaction for freezing or unfreezing an account's asset holdings.
     Must be issued by the asset's freeze manager.
@@ -587,15 +587,15 @@ class AssetFreezeTransaction(Transaction):
         target = encoding.encode_address(d["fadd"])
         new_freeze_state = d["afrz"]
 
-        af = AssetFreezeTransaction(encoding.encode_address(d["snd"]), d["fee"], fv, d["lv"],
-                                    base64.b64encode(d["gh"]).decode(), creator, index, target,
-                                    new_freeze_state, note, gen, True)
+        af = AssetFreezeTxn(encoding.encode_address(d["snd"]), d["fee"], fv, d["lv"],
+                            base64.b64encode(d["gh"]).decode(), creator, index, target,
+                            new_freeze_state, note, gen, True)
         return af
 
     def __eq__(self, other):
-        if not isinstance(other, AssetFreezeTransaction):
+        if not isinstance(other, AssetFreezeTxn):
             return False
-        return (super(AssetFreezeTransaction, self).__eq__(other) and
+        return (super(AssetFreezeTxn, self).__eq__(other) and
                 self.creator == other.creator and
                 self.index == other.index and
                 self.target == other.target and

--- a/algosdk/transaction.py
+++ b/algosdk/transaction.py
@@ -496,6 +496,111 @@ class AssetConfigTxn(Transaction):
                 self.clawback == other.clawback and
                 self.type == other.type)
 
+class AssetFreezeTransaction(Transaction):
+    """
+    Represents a transaction for freezing or unfreezing an account's asset holdings.
+    Must be issued by the asset's freeze manager.
+
+    Args:
+        sender (str): address of the sender, who must be the asset's freeze manager.
+        fee (int): transaction fee (per byte if flat_fee is false)
+        first (int): first round for which the transaction is valid
+        last (int): last round for which the transaction is valid
+        gh (str): genesis_hash
+        creator (str): creator of the asset
+        index (int): index of the asset
+        target (str): address having its assets frozen or unfrozen
+        new_freeze_state (bool): true if the assets should be frozen, false if they should be transferrable
+        note (bytes, optional): encoded NoteField object
+        gen (str, optional): genesis_id
+        flat_fee (bool): whether the specified fee is a flat fee
+
+    Attributes:
+        sender (str)
+        fee (int)
+        first_valid_round (int)
+        last_valid_round (int)
+        genesis_hash (str)
+        creator (str)
+        index (int)
+        target (str)
+        new_freeze_state (bool)
+        note (bytes)
+        genesis_id (str)
+        type (str)
+    """
+
+    def __init__(self, sender, fee, first, last, gh, creator, index, target, new_freeze_state,
+                 note=None, gen=None, flat_fee=False):
+        Transaction.__init__(self, sender, fee, first, last, note, gen, gh)
+        self.creator = creator
+        self.index = index
+        self.target = target
+        self.new_freeze_state = new_freeze_state
+        self.type = constants.assetfreeze_txn
+        if flat_fee:
+            self.fee = max(constants.min_txn_fee, self.fee)
+        else:
+            self.fee = max(self.estimate_size()*self.fee,
+                           constants.min_txn_fee)
+
+    def dictify(self):
+        od = OrderedDict()
+
+        od["fadd"] = encoding.decode_address(self.target)
+
+        faid = OrderedDict()
+        if self.creator:
+            faid["c"] = encoding.decode_address(self.creator)
+        if self.index:
+            faid["i"] = self.index
+        od["faid"] = faid
+
+        od["afrz"] = self.new_freeze_state
+
+        od["fee"] = self.fee
+        od["fv"] = self.first_valid_round
+        if self.genesis_id:
+            od["gen"] = self.genesis_id
+        od["gh"] = base64.b64decode(self.genesis_hash)
+        od["lv"] = self.last_valid_round
+        if self.note:
+            od["note"] = self.note
+        od["snd"] = encoding.decode_address(self.sender)
+        od["type"] = self.type
+
+        return od
+
+    @staticmethod
+    def undictify(d):
+        note = None
+        gen = None
+        fv = 0
+        if "note" in d:
+            note = d["note"]
+        if "gen" in d:
+            gen = d["gen"]
+        if "fv" in d:
+            fv = d["fv"]
+        creator = encoding.encode_address(d["faid"]["c"])
+        index = d["faid"]["i"]
+        target = encoding.encode_address(d["fadd"])
+        new_freeze_state = d["afrz"]
+
+        af = AssetFreezeTransaction(encoding.encode_address(d["snd"]), d["fee"], fv, d["lv"],
+                                    base64.b64encode(d["gh"]).decode(), creator, index, target,
+                                    new_freeze_state, note, gen, True)
+        return af
+
+    def __eq__(self, other):
+        if not isinstance(other, AssetFreezeTransaction):
+            return False
+        return (super(AssetFreezeTransaction, self).__eq__(other) and
+                self.creator == other.creator and
+                self.index == other.index and
+                self.target == other.target and
+                self.new_freeze_state == other.new_freeze_state and
+                self.type == other.type)
 
 class SignedTransaction:
     """

--- a/algosdk/transaction.py
+++ b/algosdk/transaction.py
@@ -626,7 +626,7 @@ class AssetTransferTxn(Transaction):
             after paying `amt` to receiver, to this address
         revocation_target (string, optional): send assets from this address, rather than the sender's address
             (can only be used by an asset's revocation manager, also known as clawback)
-        note (bytes, optional): encoded NoteField object
+        note (bytes, optional): arbitrary optional bytes
         gen (str, optional): genesis_id
         flat_fee (bool): whether the specified fee is a flat fee
 

--- a/test_unit.py
+++ b/test_unit.py
@@ -127,18 +127,26 @@ class TestTransaction(unittest.TestCase):
     def test_serialize_assetfreeze(self):
         address = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
         gh = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
-        txn = transaction.AssetFreezeTransaction(address, 10, 322575, 323575, gh,
-                                         address, 1234, address, True)
-        golden = ("iKRhcGFyhKFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh" +
-                  "/aFmxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFtxCAJ" +
-                  "+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFyxCAJ+9J2LAj4" +
-                  "bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aRjYWlkgqFjxCAJ+9J2LAj4" +
-                  "bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFpzQTSo2ZlZc0OzqJmds4A" +
-                  "BOwPomdoxCBIY7UYpLPITsgQ8i1PEIHLD3HwWaesIN7GL39w5Qk6IqJs" +
-                  "ds4ABO/3o3NuZMQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH22" +
-                  "4f2kdHlwZaRhY2Zn")
+        txn = transaction.AssetFreezeTxn(address, 10, 322575, 323575, gh,
+                                                 address, 1234, address, True)
+        golden = ("iaRmYWRkxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aRmYW" +
+                  "lkgqFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFpzQTS" +
+                  "pGFmcnrDo2ZlZc0KtKJmds4ABOwPomdoxCBIY7UYpLPITsgQ8i1PEIHLD3" +
+                  "HwWaesIN7GL39w5Qk6IqJsds4ABO/3o3NuZMQgCfvSdiwI+Gxa5r9t16ep" +
+                  "Ad5mdddQ4H6MXHaYZH224f2kdHlwZaRhZnJ6")
         self.assertEqual(encoding.msgpack_encode(txn), golden)
 
+    def test_deserialize_assetfreeze(self):
+        address = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
+        gh = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+        txn = transaction.AssetFreezeTxn(address, 10, 322575, 323575, gh,
+                                                 address, 1234, address, True)
+        golden = ("iaRmYWRkxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aRmYW" +
+                  "lkgqFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFpzQTS" +
+                  "pGFmcnrDo2ZlZc0KtKJmds4ABOwPomdoxCBIY7UYpLPITsgQ8i1PEIHLD3" +
+                  "HwWaesIN7GL39w5Qk6IqJsds4ABO/3o3NuZMQgCfvSdiwI+Gxa5r9t16ep" +
+                  "Ad5mdddQ4H6MXHaYZH224f2kdHlwZaRhZnJ6")
+        self.assertEqual(txn, encoding.msgpack_decode(golden))
 
     def test_group_id(self):
         address = "UPYAFLHSIPMJOHVXU2MPLQ46GXJKSDCEMZ6RLCQ7GWB5PRDKJUWKKXECXI"

--- a/test_unit.py
+++ b/test_unit.py
@@ -123,6 +123,21 @@ class TestTransaction(unittest.TestCase):
                   "4f2kdHlwZaRhY2Zn")
         self.assertEqual(encoding.msgpack_encode(txn), golden)
 
+    def test_serialize_assetfreeze(self):
+        address = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
+        gh = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+        txn = transaction.AssetFreezeTransaction(address, 10, 322575, 323575, gh,
+                                         address, 1234, address, True)
+        golden = ("iKRhcGFyhKFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh" +
+                  "/aFmxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFtxCAJ" +
+                  "+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFyxCAJ+9J2LAj4" +
+                  "bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aRjYWlkgqFjxCAJ+9J2LAj4" +
+                  "bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFpzQTSo2ZlZc0OzqJmds4A" +
+                  "BOwPomdoxCBIY7UYpLPITsgQ8i1PEIHLD3HwWaesIN7GL39w5Qk6IqJs" +
+                  "ds4ABO/3o3NuZMQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH22" +
+                  "4f2kdHlwZaRhY2Zn")
+        self.assertEqual(encoding.msgpack_encode(txn), golden)
+
     def test_group_id(self):
         address = "UPYAFLHSIPMJOHVXU2MPLQ46GXJKSDCEMZ6RLCQ7GWB5PRDKJUWKKXECXI"
         fromAddress, toAddress = address, address

--- a/test_unit.py
+++ b/test_unit.py
@@ -162,6 +162,20 @@ class TestTransaction(unittest.TestCase):
                   "Z111Dgfoxcdphkfbbh/aR0eXBlpWF4ZmVy")
         self.assertEqual(encoding.msgpack_encode(txn), golden)
 
+    def test_deserialize_assettransfer(self):
+        address = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
+        gh = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+        txn = transaction.AssetTransferTxn(address, 10, 322575, 323575, gh,
+                                           address, 1234, address, 1,
+                                           close_assets_to=address, revocation_target=address)
+        golden = ("i6R4YWlkgqFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/" +
+                  "aFpAaRhc25kxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/a" +
+                  "ZhY2xvc2XEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pGF" +
+                  "hbXTNBNKkYXJjdsQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH22" +
+                  "4f2jZmVlzQ3eomZ2zgAE7A+iZ2jEIEhjtRiks8hOyBDyLU8QgcsPcfBZp" +
+                  "6wg3sYvf3DlCToiomx2zgAE7/ejc25kxCAJ+9J2LAj4bFrmv23Xp6kB3m" +
+                  "Z111Dgfoxcdphkfbbh/aR0eXBlpWF4ZmVy")
+        self.assertEqual(txn, encoding.msgpack_decode(golden))
 
     def test_group_id(self):
         address = "UPYAFLHSIPMJOHVXU2MPLQ46GXJKSDCEMZ6RLCQ7GWB5PRDKJUWKKXECXI"


### PR DESCRIPTION
## Summary
This PR proposes to add a new `Transaction` subclass, `AssetFreezeTransaction`. It allows the freeze-manager of an asset to block an account from transferring assets, or for the freeze-manager to allow a frozen account to transfer assets.

### Testing
New test added to `test_unit.py`, `test_serialize_assetfreeze`. 