### PR TITLE
Content-Type is now set when sending a transaction

### DIFF
--- a/algosdk/algod.py
+++ b/algosdk/algod.py
@@ -243,9 +243,10 @@ class AlgodClient:
             res["genesisID"],
             False)
 
-    def send_raw_transaction(self, txn, **kwargs):
+    def send_raw_transaction(self, txn, headers=None, **kwargs):
         """
         Broadcast a signed transaction to the network.
+        Sets the default Content-Type header, if not previously set.
 
         Args:
             txn (str): transaction to send, encoded in base64
@@ -254,9 +255,12 @@ class AlgodClient:
         Returns:
             str: transaction ID
         """
+        tx_headers = dict(headers) if headers is not None else {}
+        if all(map(lambda x: x.lower() != "content-type", [*tx_headers])):
+            tx_headers['Content-Type'] = 'application/x-binary'
         txn = base64.b64decode(txn)
         req = "/transactions"
-        return self.algod_request("POST", req, data=txn, **kwargs)["txId"]
+        return self.algod_request("POST", req, data=txn, headers=tx_headers, **kwargs)["txId"]
 
     def send_transaction(self, txn, **kwargs):
         """


### PR DESCRIPTION
Modified `send_raw_transaction` so that a `Content-Type: application/x-binary` header is set, only if the user didn't specify a Content-Type header.
This changes are backwards compatible, and address issue #68 .
@ejbaran @JasonWeathersby