### PR TITLE
Add checks that the note field is properly formed

### DIFF
--- a/algosdk/constants.py
+++ b/algosdk/constants.py
@@ -66,6 +66,8 @@ microalgos_to_algos_ratio = 1000000
 """int: how many microalgos per algo"""
 metadata_length = 32
 """int: length of asset metadata"""
+note_max_length = 1024
+"""int: maximum length of note field"""
 lease_length = 32
 """int: byte length of leases"""
 multisig_account_limit = 255

--- a/algosdk/error.py
+++ b/algosdk/error.py
@@ -60,6 +60,11 @@ class WrongLeaseLengthError(Exception):
         Exception.__init__(self, "lease length must be 32 bytes")
 
 
+class WrongNoteType(Exception):
+    def __init(self):
+        Exception.__init__(self, "note must be of type \"bytes\"")
+
+
 class InvalidProgram(Exception):
     def __init__(self, message="invalid program for logic sig"):
         Exception.__init__(self, message)

--- a/algosdk/error.py
+++ b/algosdk/error.py
@@ -65,6 +65,11 @@ class WrongNoteType(Exception):
         Exception.__init__(self, "note must be of type \"bytes\"")
 
 
+class WrongNoteLength(Exception):
+    def __init(self):
+        Exception.__init__(self, "note length must be at most 1024")
+
+
 class InvalidProgram(Exception):
     def __init__(self, message="invalid program for logic sig"):
         Exception.__init__(self, message)

--- a/algosdk/future/transaction.py
+++ b/algosdk/future/transaction.py
@@ -59,6 +59,9 @@ class Transaction:
         self.first_valid_round = sp.first
         self.last_valid_round = sp.last
         self.note = note
+        if self.note is not None:
+            if not isinstance(self.note, bytes):
+                raise error.WrongNoteType
         self.genesis_id = sp.gen
         self.genesis_hash = sp.gh
         self.group = None

--- a/algosdk/future/transaction.py
+++ b/algosdk/future/transaction.py
@@ -62,6 +62,8 @@ class Transaction:
         if self.note is not None:
             if not isinstance(self.note, bytes):
                 raise error.WrongNoteType
+            if len(self.note) > constants.note_max_length:
+                raise error.WrongNoteLength
         self.genesis_id = sp.gen
         self.genesis_hash = sp.gh
         self.group = None

--- a/algosdk/transaction.py
+++ b/algosdk/transaction.py
@@ -25,6 +25,8 @@ class Transaction:
         if self.note is not None:
             if not isinstance(self.note, bytes):
                 raise error.WrongNoteType
+            if len(self.note) > constants.note_max_length:
+                raise error.WrongNoteLength
         self.genesis_id = gen
         self.genesis_hash = gh
         self.group = None

--- a/algosdk/transaction.py
+++ b/algosdk/transaction.py
@@ -22,6 +22,9 @@ class Transaction:
         self.first_valid_round = first
         self.last_valid_round = last
         self.note = note
+        if self.note is not None:
+            if not isinstance(self.note, bytes):
+                raise error.WrongNoteType
         self.genesis_id = gen
         self.genesis_hash = gh
         self.group = None

--- a/test_unit.py
+++ b/test_unit.py
@@ -23,12 +23,30 @@ class TestTransaction(unittest.TestCase):
                                      1000, note=b'\x00')
         self.assertEqual(constants.min_txn_fee, txn.fee)
 
+    def test_note_wrong_type(self):
+        address = "7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q"
+        gh = "JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI="
+        sp = transaction.SuggestedParams(0, 1, 100, gh)
+        f = lambda: transaction.PaymentTxn(address, sp, address, 
+                                           1000, note="hello")
+        self.assertRaises(error.WrongNoteType, f)
+
     def test_serialize(self):
         address = "7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q"
         gh = "JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI="
         sp = transaction.SuggestedParams(3, 1, 100, gh)
         txn = transaction.PaymentTxn(address, sp, address,
                                      1000, note=bytes([1, 32, 200]))
+        enc = encoding.msgpack_encode(txn)
+        re_enc = encoding.msgpack_encode(encoding.msgpack_decode(enc))
+        self.assertEqual(enc, re_enc)
+
+    def test_serialize_with_note_string_encode(self):
+        address = "7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q"
+        gh = "JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI="
+        sp = transaction.SuggestedParams(3, 1, 100, gh)
+        txn = transaction.PaymentTxn(address, sp, address,
+                                     1000, note="hello".encode())
         enc = encoding.msgpack_encode(txn)
         re_enc = encoding.msgpack_encode(encoding.msgpack_decode(enc))
         self.assertEqual(enc, re_enc)

--- a/test_unit.py
+++ b/test_unit.py
@@ -31,6 +31,14 @@ class TestTransaction(unittest.TestCase):
                                            1000, note="hello")
         self.assertRaises(error.WrongNoteType, f)
 
+    def test_note_wrong_length(self):
+        address = "7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q"
+        gh = "JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI="
+        sp = transaction.SuggestedParams(0, 1, 100, gh)
+        f = lambda: transaction.PaymentTxn(address, sp, address, 
+                                           1000, note=("0"*1025).encode())
+        self.assertRaises(error.WrongNoteLength, f)
+
     def test_serialize(self):
         address = "7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q"
         gh = "JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI="
@@ -47,6 +55,16 @@ class TestTransaction(unittest.TestCase):
         sp = transaction.SuggestedParams(3, 1, 100, gh)
         txn = transaction.PaymentTxn(address, sp, address,
                                      1000, note="hello".encode())
+        enc = encoding.msgpack_encode(txn)
+        re_enc = encoding.msgpack_encode(encoding.msgpack_decode(enc))
+        self.assertEqual(enc, re_enc)
+
+    def test_serialize_with_note_max_length(self):
+        address = "7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q"
+        gh = "JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI="
+        sp = transaction.SuggestedParams(3, 1, 100, gh)
+        txn = transaction.PaymentTxn(address, sp, address,
+                                     1000, note=("0"*1024).encode())
         enc = encoding.msgpack_encode(txn)
         re_enc = encoding.msgpack_encode(encoding.msgpack_decode(enc))
         self.assertEqual(enc, re_enc)


### PR DESCRIPTION
Check that:
* the note field is of type `bytes`.
* the note field is at most 1024-byte long.
Raises exception otherwise.

Without these checks, everything would appear to work but the transaction would be rejected by the node at the end (in the first case because the signature would be invalid).
