### PR TITLE
Raises an exception if the amount field is incorrect

### DIFF
--- a/algosdk/error.py
+++ b/algosdk/error.py
@@ -25,6 +25,11 @@ class DuplicateSigMismatchError(Exception):
         Exception.__init__(self, "mismatched duplicate signatures in multisig")
 
 
+class WrongAmountType(Exception):
+    def __init(self):
+        Exception.__init__(self, "amount (amt) must be a non-negative integer")
+
+
 class WrongChecksumError(Exception):
     def __init__(self):
         Exception.__init__(self, "checksum failed to validate")

--- a/algosdk/future/transaction.py
+++ b/algosdk/future/transaction.py
@@ -232,6 +232,8 @@ class PaymentTxn(Transaction):
                              lease, constants.payment_txn)
         self.receiver = receiver
         self.amt = amt
+        if (not isinstance(self.amt, int)) or self.amt < 0:
+            raise error.WrongAmountType
         self.close_remainder_to = close_remainder_to
         if sp.flat_fee:
             self.fee = max(constants.min_txn_fee, self.fee)
@@ -722,6 +724,8 @@ class AssetTransferTxn(Transaction):
                              lease, constants.assettransfer_txn)
         self.receiver = receiver
         self.amount = amt
+        if (not isinstance(self.amount, int)) or self.amount < 0:
+            raise error.WrongAmountType
         self.index = index
         self.close_assets_to = close_assets_to
         self.revocation_target = revocation_target

--- a/algosdk/transaction.py
+++ b/algosdk/transaction.py
@@ -198,6 +198,8 @@ class PaymentTxn(Transaction):
                              lease, constants.payment_txn)
         self.receiver = receiver
         self.amt = amt
+        if (not isinstance(self.amt, int)) or self.amt < 0:
+            raise error.WrongAmountType
         self.close_remainder_to = close_remainder_to
         if flat_fee:
             self.fee = max(constants.min_txn_fee, self.fee)
@@ -707,6 +709,8 @@ class AssetTransferTxn(Transaction):
                              lease, constants.assettransfer_txn)
         self.receiver = receiver
         self.amount = amt
+        if (not isinstance(self.amount, int)) or self.amount < 0:
+            raise error.WrongAmountType
         self.index = index
         self.close_assets_to = close_assets_to
         self.revocation_target = revocation_target

--- a/test_unit.py
+++ b/test_unit.py
@@ -450,6 +450,52 @@ class TestTransaction(unittest.TestCase):
             "nXXUOB+jFx2mGR9tuH9pHR5cGWlYXhmZXKkeGFpZAE=")
         self.assertEqual(golden, encoding.msgpack_encode(signed_txn))
 
+    def test_pay_float_amt(self):
+        address = "7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q"
+        gh = "JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI="
+        sp = transaction.SuggestedParams(3, 1, 100, gh)
+        f = lambda: transaction.PaymentTxn(address, sp, address,
+                                           10., note=bytes([1, 32, 200]))
+        self.assertRaises(error.WrongAmountType, f)
+
+    def test_pay_negative_amt(self):
+        address = "7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q"
+        gh = "JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI="
+        sp = transaction.SuggestedParams(3, 1, 100, gh)
+        f = lambda: transaction.PaymentTxn(address, sp, address,
+                                           -5, note=bytes([1, 32, 200]))
+        self.assertRaises(error.WrongAmountType, f)
+
+    def test_asset_transfer_float_amt(self):
+        address = "7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q"
+        fee = 10
+        first_round = 322575
+        last_round = 323576
+        gh = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+        index = 1
+        amount = 1.
+        to = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
+        close = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
+        sp = transaction.SuggestedParams(fee, first_round, last_round, gh)
+        f = lambda: transaction.AssetTransferTxn(
+            address, sp, to, amount, index, close)
+        self.assertRaises(error.WrongAmountType, f)
+
+    def test_asset_transfer_negative_amt(self):
+        address = "7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q"
+        fee = 10
+        first_round = 322575
+        last_round = 323576
+        gh = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+        index = 1
+        amount = -1
+        to = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
+        close = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
+        sp = transaction.SuggestedParams(fee, first_round, last_round, gh)
+        f = lambda: transaction.AssetTransferTxn(
+            address, sp, to, amount, index, close)
+        self.assertRaises(error.WrongAmountType, f)
+
     def test_group_id(self):
         address = "UPYAFLHSIPMJOHVXU2MPLQ46GXJKSDCEMZ6RLCQ7GWB5PRDKJUWKKXECXI"
         fromAddress, toAddress = address, address


### PR DESCRIPTION
Check it is a non-negative integer.
It is indeed otherwise possible to specify a floating amount
and only realize the error when sending the transaction.