### PR TITLE
[Found Work] fix incorrect size estimation exposed by test_unit.py

### DIFF
--- a/algosdk/constants.py
+++ b/algosdk/constants.py
@@ -74,8 +74,6 @@ tx_group_limit = 16
 """int: maximum number of transaction in a transaction group"""
 max_asset_decimals = 19
 """int: maximum value for decimals in assets"""
-num_additional_bytes_after_signing = 2
-"""int: number of bytes added by signature"""
 
 # logic sig related
 logic_sig_max_cost = 20000

--- a/algosdk/future/transaction.py
+++ b/algosdk/future/transaction.py
@@ -82,14 +82,12 @@ class Transaction:
         txid = base64.b32encode(txid).decode()
         return encoding._undo_padding(txid)
 
-    def sign(self, private_key, skip_rekey_check=False):
+    def sign(self, private_key):
         """
         Sign the transaction with a private key.
 
         Args:
             private_key (str): the private key of the signing account
-            skip_rekey_check (bool, optional): if set to True, do not handle authorizing_address logic
-                (typically used for size estimation)
 
         Returns:
             SignedTransaction: signed transaction with the signature
@@ -97,9 +95,25 @@ class Transaction:
         sig = self.raw_sign(private_key)
         sig = base64.b64encode(sig).decode()
         authorizing_address = None
-        if (not (self.sender == account.address_from_private_key(private_key))) and not skip_rekey_check:
+        if not (self.sender == account.address_from_private_key(private_key)):
             authorizing_address = account.address_from_private_key(private_key)
         stx = SignedTransaction(self, sig, authorizing_address)
+        return stx
+
+    def _sign_and_skip_rekey_check(self, private_key):
+        """
+        Sign the transaction with a private key, skipping rekey check.
+        This is only used for size estimation.
+
+        Args:
+            private_key (str): the private key of the signing account
+
+        Returns:
+            SignedTransaction: signed transaction with the signature
+        """
+        sig = self.raw_sign(private_key)
+        sig = base64.b64encode(sig).decode()
+        stx = SignedTransaction(self, sig)
         return stx
 
     def raw_sign(self, private_key):
@@ -122,7 +136,7 @@ class Transaction:
 
     def estimate_size(self):
         sk, _ = account.generate_account()
-        stx = self.sign(sk, skip_rekey_check=True)
+        stx = self._sign_and_skip_rekey_check(sk)
         return len(base64.b64decode(encoding.msgpack_encode(stx)))
 
     def dictify(self):


### PR DESCRIPTION
## Summary
Rekey-to transaction support #110 changed size estimation. This caused slightly different values for fee calculation, and in turn, broke the golden comparison checks in `test_unit.py`. This PR proposes to change size estimation back to the legacy way, while maintaining the new automatic-auth-address detection feature of `sign`. 

## Testing
Manually ran `python3 test_unit.py` locally; allowed Travis to run rest of tests.