### PR TITLE
Convert APP and ASA indexes to ints.

### DIFF
--- a/algosdk/future/transaction.py
+++ b/algosdk/future/transaction.py
@@ -497,7 +497,7 @@ class AssetConfigTxn(Transaction):
         if strict_empty_address_check:
             if not (manager and reserve and freeze and clawback):
                 raise error.EmptyAddressError
-        self.index = index
+        self.index = int(index)
         self.total = total
         self.default_frozen = default_frozen
         self.unit_name = unit_name
@@ -953,7 +953,7 @@ class ApplicationCallTxn(Transaction):
                  note=None, lease=None, rekey_to=None):
         Transaction.__init__(self, sender, sp, note,
                              lease, constants.appcall_txn, rekey_to)
-        self.index = index
+        self.index = int(index)
         self.on_complete = on_complete
         self.local_schema = local_schema
         self.global_schema = global_schema

--- a/algosdk/future/transaction.py
+++ b/algosdk/future/transaction.py
@@ -497,7 +497,7 @@ class AssetConfigTxn(Transaction):
         if strict_empty_address_check:
             if not (manager and reserve and freeze and clawback):
                 raise error.EmptyAddressError
-        self.index = int(index)
+        self.index = int(index) if index else None
         self.total = total
         self.default_frozen = default_frozen
         self.unit_name = unit_name
@@ -677,7 +677,7 @@ class AssetFreezeTxn(Transaction):
                  lease=None, rekey_to=None):
         Transaction.__init__(self, sender, sp, note,
                              lease, constants.assetfreeze_txn, rekey_to)
-        self.index = index
+        self.index = int(index) if index else None
         self.target = target
         self.new_freeze_state = new_freeze_state
         if sp.flat_fee:
@@ -778,7 +778,7 @@ class AssetTransferTxn(Transaction):
         self.amount = amt
         if (not isinstance(self.amount, int)) or self.amount < 0:
             raise error.WrongAmountType
-        self.index = index
+        self.index = int(index) if index else None
         self.close_assets_to = close_assets_to
         self.revocation_target = revocation_target
         if sp.flat_fee:
@@ -953,7 +953,7 @@ class ApplicationCallTxn(Transaction):
                  note=None, lease=None, rekey_to=None):
         Transaction.__init__(self, sender, sp, note,
                              lease, constants.appcall_txn, rekey_to)
-        self.index = int(index)
+        self.index = int(index) if index else None
         self.on_complete = on_complete
         self.local_schema = local_schema
         self.global_schema = global_schema


### PR DESCRIPTION
Previously, code like this:
  transaction.ApplicationNoOpTxn(bidder, params, "10382")

would silently continue, but after signing and submitting, would
report:
algosdk.error.AlgodHTTPError: msgpack decode error [pos 93]: cannot decode unsigned integer: unrecognized descriptor byte: a8/string|bytes

This is a pretty obscure error to get for using a string id instead of
an int. We could type check and give an error when creating the
transaction, but Python APIs are usually more forgiving.  This change
calls int() on the index argument, so it will try to convert strings
if needed.