### PR TITLE
Robust mnemonic

### DIFF
--- a/algosdk/future/transaction.py
+++ b/algosdk/future/transaction.py
@@ -225,6 +225,9 @@ class Transaction:
                 self.type == other.type and
                 self.rekey_to == other.rekey_to)
 
+    def __repr__(self):
+        return repr(self.dictify())
+
 
 class PaymentTxn(Transaction):
     """

--- a/algosdk/mnemonic.py
+++ b/algosdk/mnemonic.py
@@ -123,8 +123,11 @@ def _to_key(mnemonic):
     mnemonic = mnemonic.lower().split()
     if not len(mnemonic) == constants.mnemonic_len:
         raise error.WrongMnemonicLengthError
-    m_checksum = word_to_index[mnemonic[-1]]
-    mnemonic = _from_words(mnemonic[:-1])
+    try:
+        m_checksum = word_to_index[mnemonic[-1]]
+        mnemonic = _from_words(mnemonic[:-1])
+    except KeyError:            # We used to return ValueError, so keep it
+        raise ValueError(mnemonic)
     m_bytes = _to_bytes(mnemonic)
     if not m_bytes[-1:len(m_bytes)] == b'\x00':
         raise error.WrongChecksumError

--- a/test_unit.py
+++ b/test_unit.py
@@ -12,6 +12,7 @@ from algosdk import error
 from algosdk import constants
 from algosdk import util
 from algosdk import logic
+from algosdk import wordlist
 from algosdk.future import template
 from algosdk.testing import dryrun
 
@@ -834,7 +835,21 @@ class TestMnemonic(unittest.TestCase):
             "abandon abandon abandon abandon abandon abandon abandon abandon "
             "abandon abandon abandon venues abandon abandon abandon abandon "
             "invest")
-        self.assertRaises(KeyError, mnemonic._to_key, mn)
+        self.assertRaises(ValueError, mnemonic._to_key, mn)
+        mn = (
+            "abandon abandon abandon abandon abandon abandon abandon abandon "
+            "abandon abandon abandon abandon abandon abandon abandon abandon "
+            "abandon abandon abandon abandon abandon abandon abandon abandon "
+            "x-ray")
+        self.assertRaises(ValueError, mnemonic._to_key, mn)
+
+    def test_wordlist_integrity(self):
+        """This isn't a test of _checksum, it reminds us not to change the
+        wordlist.
+
+        """
+        result = mnemonic._checksum(bytes(wordlist.word_list_raw(), "utf-8"))
+        self.assertEqual(result, 1939)
 
     def test_mnemonic_wrong_len(self):
         mn = "abandon abandon abandon"


### PR DESCRIPTION
Accept mnemonic words without regard to leading/trailing whitespace,
or the type of whitespace (we used to require exactly one space (no
newlines).  Words also work even if we only have the first for (or
more) letters, since they are guarenteed unique starting there, and
some key storage devices (crytosteel) explicitly tell you only to use
the first four letters.

This also speeds things up because we store the words in a
dict instead of a list.