### PR TITLE
Do not msgpack empty leases.

### DIFF
--- a/algosdk/constants.py
+++ b/algosdk/constants.py
@@ -55,6 +55,8 @@ logic_data_prefix = b"ProgData"
 """bytes: program (logic) data prefix when signing"""
 
 
+hash_len = 32
+"""int: how long various hash-like fields should be"""
 check_sum_len_bytes = 4
 """int: how long checksums should be"""
 key_len_bytes = 32

--- a/algosdk/error.py
+++ b/algosdk/error.py
@@ -45,6 +45,13 @@ class WrongMnemonicLengthError(Exception):
         Exception.__init__(self, "mnemonic length must be 25")
 
 
+class WrongHashLengthError(Exception):
+    """General error that is normally changed to be more specific"""
+
+    def __init(self):
+        Exception.__init__(self, "length must be 32 bytes")
+
+
 class WrongKeyBytesLengthError(Exception):
     def __init__(self):
         Exception.__init__(self, "key length in bytes must be 32")

--- a/algosdk/future/transaction.py
+++ b/algosdk/future/transaction.py
@@ -72,11 +72,9 @@ class Transaction:
         """Confirm that a value is 32 bytes. If all zeros, or a falsy value, return None"""
         if not hash:
             return None
-        assert isinstance(hash, (bytes, bytearray, str)), f"{hash} is not bytes or str"
+        assert isinstance(hash, (bytes, bytearray)), f"{hash} is not bytes"
         if len(hash) != constants.hash_len:
             raise error.WrongHashLengthError
-        if isinstance(hash, str):
-            hash = hash.encode()
         if not any(hash):
             return None
         return hash

--- a/algosdk/future/transaction.py
+++ b/algosdk/future/transaction.py
@@ -59,21 +59,38 @@ class Transaction:
         self.fee = sp.fee
         self.first_valid_round = sp.first
         self.last_valid_round = sp.last
-        self.note = note
-        if self.note is not None:
-            if not isinstance(self.note, (bytes, bytearray)):
-                raise error.WrongNoteType
-            if len(self.note) > constants.note_max_length:
-                raise error.WrongNoteLength
+        self.note = self.as_note(note)
         self.genesis_id = sp.gen
         self.genesis_hash = sp.gh
         self.group = None
-        self.lease = lease
-        if self.lease is not None:
-            if len(self.lease) != constants.lease_length:
-                raise error.WrongLeaseLengthError
+        self.lease = self.as_lease(lease)
         self.type = txn_type
         self.rekey_to = rekey_to
+
+    @staticmethod
+    def as_note(note):
+        if not note:
+            return None
+        if not isinstance(note, (bytes, bytearray, str)):
+            raise error.WrongNoteType
+        if isinstance(note, str):
+            note = note.encode()
+        if len(note) > constants.note_max_length:
+                raise error.WrongNoteLength
+        return note
+
+    @staticmethod
+    def as_lease(lease):
+        if not lease:
+            return None
+        assert isinstance(lease, (bytes, bytearray, str)), f"{lease} is not bytes or str"
+        if isinstance(lease, str):
+            lease = lease.encode()
+        if len(lease) != constants.lease_length:
+            raise error.WrongLeaseLengthError
+        if not any(lease):
+            return None
+        return lease
 
     def get_txid(self):
         """

--- a/test_unit.py
+++ b/test_unit.py
@@ -51,7 +51,7 @@ class TestPaymentTransaction(unittest.TestCase):
         sp = transaction.SuggestedParams(0, 1, 100, gh)
         # 32 byte zero lease should be dropped from msgpack
         txn1 = transaction.PaymentTxn(address, sp, address,
-                                      1000, lease=("\0"*32))
+                                      1000, lease=(b"\0"*32))
         txn2 = transaction.PaymentTxn(address, sp, address,
                                       1000)
 


### PR DESCRIPTION
A lease of 32 zeros should not be msgpacked, or we get signature
errors, as the Go code does not pack it.  Check and remove such leases
at Transaction construction time.