### PR TITLE
Support new features for indexer 2.3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 unit:
-	behave --tags="@unit.offline or @unit.algod or @unit.indexer or @unit.rekey or @unit.tealsign or @unit.dryrun or @unit.responses" test -f progress2
+	behave --tags="@unit.offline or @unit.algod or @unit.indexer or @unit.rekey or @unit.tealsign or @unit.dryrun or @unit.responses or @unit.responses.231" test -f progress2
 
 integration:
-	behave --tags="@algod or @assets or @auction or @kmd or @send or @template or @indexer or @indexer.applications or @rekey or @compile or @dryrun or @dryrun.testing or @applications or @applications.verified" test -f progress2
+	behave --tags="@algod or @assets or @auction or @kmd or @send or @template or @indexer or @indexer.applications or @rekey or @compile or @dryrun or @dryrun.testing or @applications or @applications.verified or @indexer.231" test -f progress2
 
 docker-test:
 	./run_integration.sh

--- a/algosdk/v2client/algod.py
+++ b/algosdk/v2client/algod.py
@@ -301,6 +301,21 @@ class AlgodClient:
         data = base64.b64decode(data)
         return self.algod_request("POST", req, data=data, headers=headers, **kwargs)
 
+    def genesis(self, **kwargs):
+        """Returns the entire genesis file."""
+        req = "/genesis"
+        return self.algod_request("GET", req, **kwargs)
+    
+    def proof(self, round_num, txid, **kwargs):
+        """
+        Get the proof for a given transaction in a round.
+
+        Args:
+            round_num (int): The round in which the transaction appears.
+            txid (str): The transaction ID for which to generate a proof.
+        """
+        req = "/blocks/{}/transactions/{}/proof".format(round_num, txid)
+        return self.algod_request("GET", req, **kwargs)
 
 def _specify_round_string(block, round_num):
     """

--- a/algosdk/v2client/indexer.py
+++ b/algosdk/v2client/indexer.py
@@ -217,6 +217,17 @@ class IndexerClient:
 
         return self.indexer_request("GET", req, query, **kwargs)
 
+    def transaction(self, txid, **kwargs):
+        """
+        Returns information about the given transaction.
+
+        Args:
+            txid (str): The ID of the transaction to look up.
+        """
+        req = "/transactions/" + txid
+
+        return self.indexer_request("GET", req, **kwargs)
+
     def search_transactions(
         self, limit=None, next_page=None, note_prefix=None, txn_type=None,
         sig_type=None, txid=None, block=None, min_round=None, max_round=None,

--- a/algosdk/v2client/indexer.py
+++ b/algosdk/v2client/indexer.py
@@ -90,7 +90,7 @@ class IndexerClient:
     def accounts(
         self, asset_id=None, limit=None, next_page=None, min_balance=None,
         max_balance=None, block=None, auth_addr=None, application_id=None,
-        round_num=None, **kwargs):
+        round_num=None, include_all=False, **kwargs):
         """
         Return accounts that match the search; microalgos are the default
         currency unless asset_id is specified, in which case the asset will
@@ -113,6 +113,10 @@ class IndexerClient:
                 application
             round_num (int, optional): alias for block; only specify one of
                 these
+            include_all (bool, optional): include all items including closed
+                accounts, deleted applications, destroyed assets, opted-out
+                asset holdings, and closed-out application localstates. Defaults
+                to false.
         """
         req = "/accounts"
         query = dict()
@@ -131,10 +135,12 @@ class IndexerClient:
             query["auth-addr"] = auth_addr
         if application_id:
             query["application-id"] = application_id
+        if include_all:
+            query["include-all"] = include_all
         return self.indexer_request("GET", req, query, **kwargs)
 
     def asset_balances(self, asset_id, limit=None, next_page=None, min_balance=None,
-        max_balance=None, block=None, round_num=None, **kwargs):
+        max_balance=None, block=None, round_num=None, include_all=False, **kwargs):
         """
         Return accounts that hold the asset; microalgos are the default
         currency unless asset_id is specified, in which case the asset will
@@ -153,6 +159,10 @@ class IndexerClient:
                 some configurations
             round_num (int, optional): alias for block; only specify one of
                 these
+            include_all (bool, optional): include all items including closed
+                accounts, deleted applications, destroyed assets, opted-out
+                asset holdings, and closed-out application localstates. Defaults
+                to false.
         """
         req = "/assets/" + str(asset_id) + "/balances"
         query = dict()
@@ -164,6 +174,8 @@ class IndexerClient:
             query["currency-greater-than"] = min_balance
         if max_balance:
             query["currency-less-than"] = max_balance
+        if include_all:
+            query["include-all"] = include_all
         _specify_round(query, block, round_num)
         return self.indexer_request("GET", req, query, **kwargs)
 
@@ -182,7 +194,8 @@ class IndexerClient:
 
         return self.indexer_request("GET", req, **kwargs)
 
-    def account_info(self, address, block=None, round_num=None, **kwargs):
+    def account_info(self, address, block=None, round_num=None,
+        include_all=False, **kwargs):
         """
         Return account information.
 
@@ -191,10 +204,16 @@ class IndexerClient:
             block (int, optional): use results from the specified round
             round_num (int, optional): alias for block; only specify one of
                 these
+            include_all (bool, optional): include all items including closed
+                accounts, deleted applications, destroyed assets, opted-out
+                asset holdings, and closed-out application localstates. Defaults
+                to false.
         """
         req = "/accounts/" + address
         query = dict()
         _specify_round(query, block, round_num)
+        if include_all:
+            query["include-all"] = include_all
 
         return self.indexer_request("GET", req, query, **kwargs)
 
@@ -464,7 +483,7 @@ class IndexerClient:
 
     def search_assets(
         self, limit=None, next_page=None, creator=None, name=None, unit=None,
-        asset_id=None, **kwargs):
+        asset_id=None, include_all=False, **kwargs):
         """
         Return assets that satisfy the conditions.
 
@@ -477,6 +496,10 @@ class IndexerClient:
             name (str, optional): filter just assets with the given name
             unit (str, optional): filter just assets with the given unit
             asset_id (int, optional): return only the asset with this ID
+            include_all (bool, optional): include all items including closed
+                accounts, deleted applications, destroyed assets, opted-out
+                asset holdings, and closed-out application localstates. Defaults
+                to false.
         """
         req = "/assets"
         query = dict()
@@ -492,49 +515,66 @@ class IndexerClient:
             query["unit"] = unit
         if asset_id:
             query["asset-id"] = asset_id
+        if include_all:
+            query["include-all"] = include_all
 
         return self.indexer_request("GET", req, query, **kwargs)
 
-    def asset_info(self, asset_id, **kwargs):
+    def asset_info(self, asset_id, include_all=False, **kwargs):
         """
         Return asset information.
 
         Args:
             asset_id (int): asset index
+            include_all (bool, optional): include all items including closed
+                accounts, deleted applications, destroyed assets, opted-out
+                asset holdings, and closed-out application localstates. Defaults
+                to false.
         """
         req = "/assets/" + str(asset_id)
-        return self.indexer_request("GET", req, **kwargs)
+        query = dict()
+        if include_all:
+            query["include-all"] = include_all
+        return self.indexer_request("GET", req, query, **kwargs)
 
-    def applications(
-            self, application_id, round=None, round_num=None, **kwargs):
+    def applications(self, application_id, round=None, round_num=None,
+        include_all=False, **kwargs):
         """
         Return applications that satisfy the conditions.
 
         Args:
             application_id (int): application index
-            round (int, optional): restrict search to passed round;
-                deprecated, please use round_num
-            round_num (int, optional): alias for round; only specify one of these
+            round (int, optional): not supported, DO NOT USE!
+            round_num (int, optional): not supported, DO NOT USE!
+            include_all (bool, optional): include all items including closed
+                accounts, deleted applications, destroyed assets, opted-out
+                asset holdings, and closed-out application localstates. Defaults
+                to false.
         """
         req = "/applications/" + str(application_id)
         query = dict()
         _specify_round(query, round, round_num)
+        if include_all:
+            query["include-all"] = include_all
 
         return self.indexer_request("GET", req, query, **kwargs)
 
     def search_applications(
             self, application_id=None, round=None, limit=None, next_page=None,
-            round_num=None, **kwargs):
+            round_num=None, include_all=False, **kwargs):
         """
         Return applications that satisfy the conditions.
 
         Args:
             application_id (int, optional): restrict search to application index
-            round (int, optional): restrict search to passed round
-                deprecated, please use round_num
+            round (int, optional): not supported, DO NOT USE!
             limit (int, optional): restrict number of results to limit
             next_page (string, optional): used for pagination
-            round_num (int, optional): alias for round; only specify one of these
+            round_num (int, optional): not supported, DO NOT USE!
+            include_all (bool, optional): include all items including closed
+                accounts, deleted applications, destroyed assets, opted-out
+                asset holdings, and closed-out application localstates. Defaults
+                to false.
         """
         req = "/applications"
         query = dict()
@@ -545,6 +585,8 @@ class IndexerClient:
             query["limit"] = limit
         if next_page:
             query["next"] = next_page
+        if include_all:
+            query["include-all"] = include_all
 
         return self.indexer_request("GET", req, query, **kwargs)
 

--- a/test/steps/v2_steps.py
+++ b/test/steps/v2_steps.py
@@ -14,7 +14,7 @@ from algosdk import account, encoding, error, mnemonic
 from algosdk.v2client import *
 from algosdk.v2client.models import DryrunRequest, DryrunSource, \
     Account, Application, ApplicationLocalState
-from algosdk.error import AlgodHTTPError
+from algosdk.error import AlgodHTTPError, IndexerHTTPError
 from algosdk.testing.dryrun import DryrunTestCaseMixin
 
 from test.steps.steps import token as daemon_token
@@ -27,6 +27,13 @@ def parse_string(text):
 
 register_type(MaybeString=parse_string)
 
+@parse.with_pattern(r"true|false")
+def parse_bool(value):
+    if value not in ("true", "false"):
+        raise ValueError("Unknown value for include_all: {}".format(value))
+    return value == "true"
+
+register_type(MaybeBool=parse_bool)
 
 @given("mock server recording request paths")
 def setup_mockserver(context):
@@ -598,6 +605,16 @@ def search_accounts(context, index, limit, currencyGreaterThan, currencyLessThan
                                             max_balance=int(currencyLessThan), block=int(block), auth_addr=authAddr)
 
 @when(
+    'I use {indexer} to search for an account with {assetid}, {limit}, {currencygt}, {currencylt}, "{auth_addr:MaybeString}", {application_id}, "{include_all:MaybeBool}" and token "{token:MaybeString}"')
+def icl_search_accounts_with_auth_addr_and_app_id_and_include_all(context, indexer, assetid, limit, currencygt, currencylt, auth_addr, application_id, include_all, token):
+    context.response = context.icls[indexer].accounts(asset_id=int(assetid), limit=int(limit), next_page=token,
+                                                      min_balance=int(currencygt),
+                                                      max_balance=int(currencylt),
+                                                      auth_addr=auth_addr,
+                                                      application_id=int(application_id),
+                                                      include_all=include_all)
+
+@when(
     'I use {indexer} to search for an account with {assetid}, {limit}, {currencygt}, {currencylt}, "{auth_addr:MaybeString}", {application_id} and token "{token:MaybeString}"')
 def icl_search_accounts_with_auth_addr_and_app_id(context, indexer, assetid, limit, currencygt, currencylt, auth_addr, application_id, token):
     context.response = context.icls[indexer].accounts(asset_id=int(assetid), limit=int(limit), next_page=token,
@@ -605,7 +622,6 @@ def icl_search_accounts_with_auth_addr_and_app_id(context, indexer, assetid, lim
                                                       max_balance=int(currencylt),
                                                       auth_addr=auth_addr,
                                                       application_id=int(application_id))
-
 
 @when(
     'I use {indexer} to search for an account with {assetid}, {limit}, {currencygt}, {currencylt} and token "{token:MaybeString}"')
@@ -906,24 +922,33 @@ def check_assets(context, num, assetidout):
     if int(num) > 0:
         assert context.response["assets"][0]["index"] == int(assetidout)
 
+@when('I use {indexer} to search for applications with {limit}, {application_id}, "{include_all:MaybeBool}" and token "{token:MaybeString}"')
+def search_applications_include_all(context, indexer, limit, application_id, include_all, token):
+    context.response = context.icls[indexer].search_applications(application_id=int(application_id),limit=int(limit),
+                                                                 include_all=include_all,next_page=token)
 
 @when('I use {indexer} to search for applications with {limit}, {application_id}, and token "{token:MaybeString}"')
-def step_impl(context, indexer, limit, application_id, token):
+def search_applications(context, indexer, limit, application_id, token):
     context.response = context.icls[indexer].search_applications(application_id=int(application_id),limit=int(limit),
                                                                  next_page=token)
 
+@when('I use {indexer} to lookup application with {application_id} and "{include_all:MaybeBool}"')
+def lookup_application_include_all(context, indexer, application_id, include_all):
+    try:
+        context.response = context.icls[indexer].applications(application_id=int(application_id), include_all=include_all)
+    except IndexerHTTPError as e:
+        context.response = json.loads(str(e))
 
 @when('I use {indexer} to lookup application with {application_id}')
-def step_impl(context, indexer, application_id):
+def lookup_application(context, indexer, application_id):
     context.response = context.icls[indexer].applications(application_id=int(application_id))
-
 
 @then(u'the parsed response should equal "{jsonfile}".')
 def step_impl(context, jsonfile):
     loaded_response = None
     dir_path = os.path.dirname(os.path.realpath(__file__))
     dir_path = os.path.dirname(os.path.dirname(dir_path))
-    with open(dir_path + "/test-harness/features/resources/" + jsonfile, "rb") as f:
+    with open(dir_path + "/test/features/resources/" + jsonfile, "rb") as f:
         loaded_response = bytearray(f.read())
     # sort context.response
     def recursively_sort_on_key(dictionary):
@@ -1085,12 +1110,12 @@ def build_app_transaction(context, operation, application_id, sender, approval_p
     if approval_program == "none":
         approval_program = None
     elif approval_program:
-        with open(dir_path + "/test-harness/features/resources/" + approval_program, "rb") as f:
+        with open(dir_path + "/test/features/resources/" + approval_program, "rb") as f:
             approval_program = bytearray(f.read())
     if clear_program == "none":
         clear_program = None
     elif clear_program:
-        with open(dir_path + "/test-harness/features/resources/" + clear_program, "rb") as f:
+        with open(dir_path + "/test/features/resources/" + clear_program, "rb") as f:
             clear_program = bytearray(f.read())
     if app_args == "none":
         app_args = None
@@ -1172,12 +1197,12 @@ def build_app_txn_with_transient(context, operation, approval_program, clear_pro
     if approval_program == "none":
         approval_program = None
     elif approval_program:
-        with open(dir_path + "/test-harness/features/resources/" + approval_program, "rb") as f:
+        with open(dir_path + "/test/features/resources/" + approval_program, "rb") as f:
             approval_program = bytearray(f.read())
     if clear_program == "none":
         clear_program = None
     elif clear_program:
-        with open(dir_path + "/test-harness/features/resources/" + clear_program, "rb") as f:
+        with open(dir_path + "/test/features/resources/" + clear_program, "rb") as f:
             clear_program = bytearray(f.read())
     if int(local_ints) == 0 and int(local_bytes) == 0:
         local_schema = None


### PR DESCRIPTION
Add support for the new `include-all` query param on some indexer endpoints, and add support for relevant cucumber tests.

Like the JS SDK (algorand/js-algorand-sdk#296), the application endpoints also contained query params for `round`. I chose not to remove these arguments completely since that would cause a breaking change for anyone who calls the functions normally (i.e. without keyword args), so instead I've changed their descriptions to discourage use.

Closes #180.