### PR TITLE
Add missing Algod endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 unit:
-	behave --tags="@unit.offline or @unit.algod or @unit.indexer or @unit.rekey or @unit.tealsign or @unit.dryrun or @unit.responses or @unit.responses.231" test -f progress2
+	behave --tags="@unit.offline or @unit.algod or @unit.indexer or @unit.rekey or @unit.tealsign or @unit.dryrun or @unit.applications or @unit.responses or @unit.transactions or @unit.responses.231" test -f progress2
 
 integration:
 	behave --tags="@algod or @assets or @auction or @kmd or @send or @template or @indexer or @indexer.applications or @rekey or @compile or @dryrun or @dryrun.testing or @applications or @applications.verified or @indexer.231" test -f progress2

--- a/algosdk/v2client/algod.py
+++ b/algosdk/v2client/algod.py
@@ -94,6 +94,26 @@ class AlgodClient:
         """
         req = "/accounts/" + address
         return self.algod_request("GET", req, **kwargs)
+    
+    def asset_info(self, asset_id, **kwargs):
+        """
+        Return information about a specific asset.
+
+        Args:
+            asset_id (int): The ID of the asset to look up.
+        """
+        req = "/assets/" + str(asset_id)
+        return self.algod_request("GET", req, **kwargs)
+    
+    def application_info(self, application_id, **kwargs):
+        """
+        Return information about a specific application.
+
+        Args:
+            application_id (int): The ID of the application to look up.
+        """
+        req = "/applications/" + str(application_id)
+        return self.algod_request("GET", req, **kwargs)
 
     def pending_transactions_by_address(self, address, limit=0, response_format="json",
                                         **kwargs):

--- a/test/steps/v2_steps.py
+++ b/test/steps/v2_steps.py
@@ -225,6 +225,13 @@ def acc_info_any(context):
 def parse_acc_info(context, address):
     assert context.response["address"] == address
 
+@when('we make a GetAssetByID call for assetID {asset_id}')
+def asset_info(context, asset_id):
+    context.response = context.acl.asset_info(int(asset_id))
+
+@when(u'we make a GetApplicationByID call for applicationID {app_id}')
+def application_info(context, app_id):
+    context.response = context.acl.application_info(int(app_id))
 
 @when('we make a Get Block call against block number {block} with format "{response_format}"')
 def block(context, block, response_format):
@@ -586,6 +593,13 @@ def lookup_asset_any(context):
 def parse_asset(context, index):
     assert context.response["asset"]["index"] == int(index)
 
+@when('we make a LookupApplications call with applicationID {app_id}')
+def lookup_application(context, app_id):
+    context.response = context.icl.applications(int(app_id))
+
+@when('we make a SearchForApplications call with applicationID {app_id}')
+def search_application(context, app_id):
+    context.response = context.icl.search_applications(int(app_id))
 
 @when(
     'we make a Search Accounts call with assetID {index} limit {limit} currencyGreaterThan {currencyGreaterThan} currencyLessThan {currencyLessThan} and round {block}')

--- a/test/steps/v2_steps.py
+++ b/test/steps/v2_steps.py
@@ -229,7 +229,7 @@ def parse_acc_info(context, address):
 def asset_info(context, asset_id):
     context.response = context.acl.asset_info(int(asset_id))
 
-@when(u'we make a GetApplicationByID call for applicationID {app_id}')
+@when('we make a GetApplicationByID call for applicationID {app_id}')
 def application_info(context, app_id):
     context.response = context.acl.application_info(int(app_id))
 


### PR DESCRIPTION
Add the missing `asset_info()` and `application_info()` methods to the v2 `AlgodClient` class.

Closes #188.