### PR TITLE
Add type check to AssetTransferTxn index

### DIFF
--- a/algosdk/transaction.py
+++ b/algosdk/transaction.py
@@ -742,6 +742,8 @@ class AssetTransferTxn(Transaction):
         self.amount = amt
         if (not isinstance(self.amount, int)) or self.amount < 0:
             raise error.WrongAmountType
+        if type(index) != int:
+            raise TypeError("Index must be an int")
         self.index = index
         self.close_assets_to = close_assets_to
         self.revocation_target = revocation_target


### PR DESCRIPTION
If index is passed as a string, a hardly understandable error 400 is passed by the API with error `msgpack decode error [pos 486]: cannot decode unsigned integer: unrecognized descriptor byte: a8/string|bytes`
This change raise an error in case the type of index variable is not an int