### PR TITLE
Solve Issue #169: Merge Request headers in `algod.py`

### DIFF
--- a/algosdk/util.py
+++ b/algosdk/util.py
@@ -85,6 +85,6 @@ def build_headers_from(kwarg_headers: Dict[str, Any], additional_headers: Dict[s
     if kwarg_headers:
         kwarg_headers.update(additional_headers)
     else:
-        kwarg_headers = { 'Content-Type': 'application/x-binary' }
+        kwarg_headers = additional_headers
     
     return kwarg_headers

--- a/algosdk/util.py
+++ b/algosdk/util.py
@@ -73,14 +73,14 @@ def verify_bytes(message, signature, public_key):
 
 def build_headers_from(kwarg_headers: Dict[str, Any], additional_headers: Dict[str, Any]):
     """
-    Build correct kwargs representation for `AlgodClient.algod_request`.
+    Build correct headers for `AlgodClient.algod_request`.
 
     Args:
-        kwarg_headers (Dict[str, Any]): kwargs passed for request
-        additional_headers (Dict[str, Any]): additional headers to pass to self.algod_request
+        kwarg_headers (Dict[str, Any]): headers passed through kwargs.
+        additional_headers (Dict[str, Any]): additional headers to pass to `AlgodClient.algod_request`
 
     Returns:
-        Dict[str, any]: final version of headers dictionary to be used for self.algod_request
+        Dict[str, any]: final version of headers dictionary to be used for `AlgodClient.algod_request`
     """
     if kwarg_headers:
         kwarg_headers.update(additional_headers)

--- a/algosdk/util.py
+++ b/algosdk/util.py
@@ -4,7 +4,7 @@ import decimal
 import base64
 from nacl.signing import SigningKey, VerifyKey
 from nacl.exceptions import BadSignatureError
-
+from typing import Dict, Any
 
 def microalgos_to_algos(microalgos):
     """
@@ -70,3 +70,21 @@ def verify_bytes(message, signature, public_key):
         return True
     except BadSignatureError:
         return False
+
+def build_headers_from(kwarg_headers: Dict[str, Any], additional_headers: Dict[str, Any]):
+    """
+    Build correct kwargs representation for `AlgodClient.algod_request`.
+
+    Args:
+        kwarg_headers (Dict[str, Any]): kwargs passed for request
+        additional_headers (Dict[str, Any]): additional headers to pass to self.algod_request
+
+    Returns:
+        Dict[str, any]: final version of headers dictionary to be used for self.algod_request
+    """
+    if kwarg_headers:
+        kwarg_headers.update(additional_headers)
+    else:
+        kwarg_headers = { 'Content-Type': 'application/x-binary' }
+    
+    return kwarg_headers

--- a/algosdk/v2client/algod.py
+++ b/algosdk/v2client/algod.py
@@ -211,7 +211,7 @@ class AlgodClient:
         headers = util.build_headers_from(kwargs.get("headers", False), {'Content-Type': 'application/x-binary'})
         kwargs["headers"] = headers
 
-        return self.algod_request("POST", req, data=txn, headers=headers, **kwargs)["txId"]
+        return self.algod_request("POST", req, data=txn, **kwargs)["txId"]
 
     def pending_transactions(self, max_txns=0, response_format="json", **kwargs):
         """
@@ -307,7 +307,7 @@ class AlgodClient:
         headers = util.build_headers_from(kwargs.get("headers", False), { 'Content-Type': 'application/x-binary' })
         kwargs["headers"] = headers
 
-        return self.algod_request("POST", req, data=source.encode('utf-8'), headers=headers, **kwargs)
+        return self.algod_request("POST", req, data=source.encode('utf-8'), **kwargs)
 
     def dryrun(self, drr, **kwargs):
         """
@@ -326,7 +326,7 @@ class AlgodClient:
         data = encoding.msgpack_encode(drr)
         data = base64.b64decode(data)
 
-        return self.algod_request("POST", req, data=data, headers=headers, **kwargs)
+        return self.algod_request("POST", req, data=data, **kwargs)
 
     def genesis(self, **kwargs):
         """Returns the entire genesis file."""

--- a/algosdk/v2client/algod.py
+++ b/algosdk/v2client/algod.py
@@ -8,6 +8,7 @@ from .. import encoding
 from .. import constants
 from .. import future
 import msgpack
+from .. import util
 
 api_version_path_prefix = "/v2"
 
@@ -207,7 +208,9 @@ class AlgodClient:
         """
         txn = base64.b64decode(txn)
         req = "/transactions"
-        headers = { 'Content-Type': 'application/x-binary' }
+        headers = util.build_headers_from(kwargs.get("headers", False), {'Content-Type': 'application/x-binary'})
+        kwargs["headers"] = headers
+
         return self.algod_request("POST", req, data=txn, headers=headers, **kwargs)["txId"]
 
     def pending_transactions(self, max_txns=0, response_format="json", **kwargs):
@@ -301,7 +304,9 @@ class AlgodClient:
 
         """
         req = "/teal/compile"
-        headers = { 'Content-Type': 'application/x-binary' }
+        headers = util.build_headers_from(kwargs.get("headers", False), { 'Content-Type': 'application/x-binary' })
+        kwargs["headers"] = headers
+
         return self.algod_request("POST", req, data=source.encode('utf-8'), headers=headers, **kwargs)
 
     def dryrun(self, drr, **kwargs):
@@ -316,9 +321,11 @@ class AlgodClient:
             dict: loaded from json response body
         """
         req = "/teal/dryrun"
-        headers = { 'Content-Type': 'application/msgpack' }
+        headers = util.build_headers_from(kwargs.get("headers", False), {'Content-Type': 'application/msgpack'})
+        kwargs["headers"] = headers
         data = encoding.msgpack_encode(drr)
         data = base64.b64decode(data)
+
         return self.algod_request("POST", req, data=data, headers=headers, **kwargs)
 
     def genesis(self, **kwargs):


### PR DESCRIPTION
Previously, under certain circumstances, if a developer passed their own `headers` to the `send_raw_transaction` method, the following error would occur:

```
TypeError: algosdk.v2client.algod.AlgodClient.algod_request() got multiple values for keyword argument 'headers'
```

This is because the headers defined in `send_raw_transaction` are passed along to `self.algod_request` with the headers that the Algorand SDK automatically passes. This creates duplicate header kwargs, resulting in the above `TypeError`. This PR attempts to solve this problem.

More context is provided in #169. CC: @jasonpaulos 