### PR TITLE
Python < 3.7 bug fixed

### DIFF
--- a/algosdk/future/transaction.py
+++ b/algosdk/future/transaction.py
@@ -75,7 +75,7 @@ class Transaction:
         """Confirm that a value is 32 bytes. If all zeros, or a falsy value, return None"""
         if not hash:
             return None
-        assert isinstance(hash, (bytes, bytearray)), f"{hash} is not bytes"
+        assert isinstance(hash, (bytes, bytearray)), "{} is not bytes".format(hash)
         if len(hash) != constants.hash_len:
             raise error.WrongHashLengthError
         if not any(hash):
@@ -266,7 +266,7 @@ class Transaction:
     @staticmethod
     def required(arg):
         if not arg:
-            raise ValueError(f"{arg} supplied as a required argument")
+            raise ValueError("{} supplied as a required argument".format(arg))
         return arg
 
     @staticmethod
@@ -1365,7 +1365,7 @@ class ApplicationCallTxn(Transaction):
         """Confirm the argument is a StateSchema, or false which is coerced to None"""
         if not schema or not schema.dictify():
             return None         # Coerce false/empty values to None, to help __eq__
-        assert isinstance(schema, StateSchema), f"{schema} is not a StateSchema"
+        assert isinstance(schema, StateSchema), "{} is not a StateSchema".format(schema)
         return schema
 
     @staticmethod
@@ -1373,7 +1373,7 @@ class ApplicationCallTxn(Transaction):
         """Confirm the argument is bytes-like, or false which is coerced to None"""
         if not teal:
             return None         # Coerce false values like "" to None, to help __eq__
-        assert isinstance(teal, (bytes, bytearray)), f"Program {teal} is not bytes"
+        assert isinstance(teal, (bytes, bytearray)), "Program {} is not bytes".format(teal)
         return teal
 
     @staticmethod
@@ -1387,7 +1387,7 @@ class ApplicationCallTxn(Transaction):
             if isinstance(e, int):
                 # Uses 8 bytes, big endian to match TEAL's btoi
                 return e.to_bytes(8, "big")  # raises for negative or too big
-            assert False, f"{e} is not bytes, str, or int"
+            assert False, "{} is not bytes, str, or int".format(e)
 
         if not lst:
             return None

--- a/algosdk/v2client/algod.py
+++ b/algosdk/v2client/algod.py
@@ -191,7 +191,7 @@ class AlgodClient:
             str: transaction ID
         """
         assert not isinstance(txn, future.transaction.Transaction), \
-            f"Attempt to send UNSIGNED transaction {txn}"
+            "Attempt to send UNSIGNED transaction {}".format(txn)
         return self.send_raw_transaction(encoding.msgpack_encode(txn),
                                          **kwargs)
 
@@ -269,7 +269,7 @@ class AlgodClient:
         serialized = []
         for txn in txns:
             assert not isinstance(txn, future.transaction.Transaction), \
-                f"Attempt to send UNSIGNED transaction {txn}"
+                "Attempt to send UNSIGNED transaction {}".format(txn)
             serialized.append(base64.b64decode(encoding.msgpack_encode(txn)))
 
         return self.send_raw_transaction(base64.b64encode(


### PR DESCRIPTION
The current version of `py-algorand-sdk` doesn't work on Python < 3.7.
f-Strings was introduced in Python 3.7, so I changed it to a more general method (`str.format`) to be backward compatible.

## Current version
![SS](https://user-images.githubusercontent.com/7515099/128345775-ff2ea8d9-ebf9-416b-a7eb-40deaf876ee9.png)

## This PR
![SS2](https://user-images.githubusercontent.com/7515099/128345819-3183edf9-e6f1-463e-a92e-2dcf4d2e8b21.png)

