### PR TITLE
Fix JSON decoding in AlgodHTTPError

### DIFF
--- a/algosdk/v2client/algod.py
+++ b/algosdk/v2client/algod.py
@@ -75,8 +75,8 @@ class AlgodClient:
             code = e.code
             e = e.read().decode("utf-8")
             try:
-                raise error.AlgodHTTPError(json.loads(e)["message"], code)
-            except:
+                e = json.loads(e)["message"]
+            finally:
                 raise error.AlgodHTTPError(e, code)
         if response_format == "json":
             try:

--- a/algosdk/v2client/indexer.py
+++ b/algosdk/v2client/indexer.py
@@ -72,8 +72,8 @@ class IndexerClient:
         except urllib.error.HTTPError as e:
             e = e.read().decode("utf-8")
             try:
-                raise error.IndexerHTTPError(json.loads(e)["message"])
-            except:
+                e = json.loads(e)["message"]
+            finally:
                 raise error.IndexerHTTPError(e)
         response_dict = json.loads(resp.read().decode("utf-8"))
 

--- a/test/steps/v2_steps.py
+++ b/test/steps/v2_steps.py
@@ -77,6 +77,7 @@ def step_impl(context, filename, directory, status):
 def validate_error(context, err):
     if context.expected_status_code != 200:
         if context.expected_status_code == 500:
+            print(context.expected_mock_response, err.args[0])
             assert context.expected_mock_response == json.loads(err.args[0])
         else:
             raise NotImplementedError("test does not know how to validate status code " + context.expected_status_code)

--- a/test/steps/v2_steps.py
+++ b/test/steps/v2_steps.py
@@ -77,8 +77,7 @@ def step_impl(context, filename, directory, status):
 def validate_error(context, err):
     if context.expected_status_code != 200:
         if context.expected_status_code == 500:
-            print(context.expected_mock_response, err.args[0])
-            assert context.expected_mock_response == json.loads(err.args[0])
+            assert context.expected_mock_response['message'] == err.args[0], (context.expected_mock_response, err.args[0])
         else:
             raise NotImplementedError("test does not know how to validate status code " + context.expected_status_code)
     else:

--- a/test_integration.py
+++ b/test_integration.py
@@ -486,6 +486,7 @@ class TestIntegration(unittest.TestCase):
             send = self.acl.send_transactions([stxn1])
             self.assertEqual(send, txn.get_txid())
         except error.AlgodHTTPError as ex:
+            self.assertNotIn('{"message"', str(ex))
             self.assertIn(
                 "TransactionPool.Remember: transaction groups not supported",
                 str(ex))


### PR DESCRIPTION
The following would always raise an exception in the `try` block and raise the second exception from the `except` without parsing the JSON `message` received in the HTTP response.

```python
            try:
                 raise error.AlgodHTTPError(json.loads(e)["message"], code)
            except:
                 raise error.AlgodHTTPError(e, code)
```

If the intent was to decode the JSON in the exception, this PR fixes the behaviour. Before: 

```
{"message":"TransactionPool.Remember: transaction CON6STFUWXIL3JHMHQOTSM5753NKOJKONGUVTD43DIG2P2ZRCMMA: asset 110 frozen in GSRKKDAQNOKAL4JJDJJLJUB3ZJFKTRI4NHXZ4QHYYPXSOE3EEWSWB43PRM"}
```

After:

```
TransactionPool.Remember: transaction CON6STFUWXIL3JHMHQOTSM5753NKOJKONGUVTD43DIG2P2ZRCMMA: asset 110 frozen in GSRKKDAQNOKAL4JJDJJLJUB3ZJFKTRI4NHXZ4QHYYPXSOE3EEWSWB43PRM
```

I have added a small integration test, but I can't run the Docker tests because `indexer` fails to build (locally and on CI).