### PR TITLE
Change __init__.py to include v2client import

### DIFF
--- a/algosdk/__init__.py
+++ b/algosdk/__init__.py
@@ -12,6 +12,7 @@ from . import mnemonic
 from . import template
 from . import transaction
 from . import util
+from . import v2client
 from . import wallet
 from . import wordlist
 


### PR DESCRIPTION
I propose this change to help language servers with their work. Unless there is a good reason to keep v2 out of the \_\_init\_\_ file, I think the v2client should be added too.