### PR TITLE
Add CircleCI configs to the Python SDK repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     machine: 
-      image: "ubuntu-2004:202101-01"
+      image: "ubuntu-2004:202104-01"
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Adds CircleCI `config.yml` to the Python SDK repo so we can migrate away from Travis CI.