### PR TITLE
Add requirement to fetch behave source code and update readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR $HOME/py-algorand-sdk
 
 # SDK dependencies, and source version of behave with tag expression support
 RUN pip install . -q \
-    && pip install git+https://github.com/behave/behave -q
+    && pip install -r requirements.txt -q
 
 # Run integration tests
 CMD ["/bin/bash", "-c", "make unit && make integration"]

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ Install dependencies
 
 Run tests
 * `make docker-test`
-* `make unit` (only unit tests)
-* `make integration` (only integration tests)
 
 Format code:
 * `black .`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,16 @@ Alternatively, choose a [distribution file](https://pypi.org/project/py-algorand
 
 ## SDK Development
 
-Run tests with `make docker-test`
+Install dependencies
+* `pip install -r requirements.txt`
+
+Run tests
+* `make docker-test`
+* `make unit` (only unit tests)
+* `make integration` (only integration tests)
+
+Format code:
+* `black .`
 
 ## Quick start
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 .
 black==21.9b0
+git+https://github.com/behave/behave


### PR DESCRIPTION
This PR makes a README change to add details to the development section and specify the `requirements.txt` to fetch the latest `behave` for tag support.

Thanks to @barnjamin for this suggestion 😃 