### PR TITLE
Add CircleCI build step to generate docsets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,8 @@ jobs:
             pip install sphinx sphinx_rtd_theme doc2dash
             make html
             doc2dash --name py-algo-sdk --index-page index.html --online-redirect-url https://py-algorand-sdk.readthedocs.io/en/latest/ _build/html
-            mv py-algo-sdk.docset /tmp
+            tar -czvf py-algo-sdk.docset.tar.gz py-algo-sdk.docset
+            mv py-algo-sdk.docset.tar.gz /tmp
       - store_artifacts:
-          path: /tmp/py-algo-sdk.docset
-          destination: py-algo-sdk.docset
+          path: /tmp/py-algo-sdk.docset.tar.gz
+          destination: py-algo-sdk.docset.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ workflows:
     jobs:
       - unit-test
       - integration-test
+      - docset
 
 jobs:
   unit-test:
@@ -22,3 +23,22 @@ jobs:
     steps:
       - checkout
       - run: make docker-test
+  docset:
+    docker:
+      # NOTE: We might eventually need Docker authentication here.
+      - image: cimg/python:3.9
+    steps:
+      - checkout
+      - run:
+          # NOTE: We might add caching at `pip` level here.
+          command: |
+            pip install -r requirements.txt
+            cd docs
+            pip install -r requirements.txt
+            pip install sphinx sphinx_rtd_theme doc2dash
+            make html
+            doc2dash --name py-algo-sdk --index-page index.html --online-redirect-url https://py-algorand-sdk.readthedocs.io/en/latest/ _build/html
+            mv py-algo-sdk.docset /tmp
+      - store_artifacts:
+          path: /tmp/py-algo-sdk.docset
+          destination: py-algo-sdk.docset

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,1 @@
+py-algo-sdk.docset


### PR DESCRIPTION
This PR adds a CircleCI build step to generate docsets for [Kapeli's Dash](https://kapeli.com/dash) and [zeal](https://zealdocs.org). The result is uploaded as a CircleCI artifact.

I was doing these steps manually as I tend to access the docs quite often, so thought to automate it. If not useful/interesting we can just close this. :)

Looks like this:
<img width="1121" alt="Screenshot 2022-02-08 at 11 57 01" src="https://user-images.githubusercontent.com/1721633/152973790-987dd031-151c-45dc-97b1-75117540194b.png">

