### PR TITLE
Add ABI and ATC to Sphinx

### DIFF
--- a/docs/algosdk/abi/__init__.rst
+++ b/docs/algosdk/abi/__init__.rst
@@ -1,0 +1,7 @@
+__init__
+========
+
+.. automodule:: algosdk.abi.__init__
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/algosdk/abi/__init__.rst
+++ b/docs/algosdk/abi/__init__.rst
@@ -1,7 +1,0 @@
-__init__
-========
-
-.. automodule:: algosdk.abi.__init__
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/algosdk/abi/address_type.rst
+++ b/docs/algosdk/abi/address_type.rst
@@ -1,0 +1,7 @@
+address_type
+============
+
+.. automodule:: algosdk.abi.address_type
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/algosdk/abi/array_dynamic_type.rst
+++ b/docs/algosdk/abi/array_dynamic_type.rst
@@ -1,0 +1,7 @@
+array_dynamic_type
+==================
+
+.. automodule:: algosdk.abi.array_dynamic_type
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/algosdk/abi/array_static_type.rst
+++ b/docs/algosdk/abi/array_static_type.rst
@@ -1,0 +1,7 @@
+array_static_type
+=================
+
+.. automodule:: algosdk.abi.array_static_type
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/algosdk/abi/base_type.rst
+++ b/docs/algosdk/abi/base_type.rst
@@ -1,0 +1,7 @@
+base_type
+=========
+
+.. automodule:: algosdk.abi.base_type
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/algosdk/abi/bool_type.rst
+++ b/docs/algosdk/abi/bool_type.rst
@@ -1,0 +1,7 @@
+bool_type
+=========
+
+.. automodule:: algosdk.abi.bool_type
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/algosdk/abi/byte_type.rst
+++ b/docs/algosdk/abi/byte_type.rst
@@ -1,0 +1,7 @@
+byte_type
+=========
+
+.. automodule:: algosdk.abi.byte_type
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/algosdk/abi/contract.rst
+++ b/docs/algosdk/abi/contract.rst
@@ -1,0 +1,7 @@
+contract
+========
+
+.. automodule:: algosdk.abi.contract
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/algosdk/abi/index.rst
+++ b/docs/algosdk/abi/index.rst
@@ -1,0 +1,20 @@
+abi
+======
+.. toctree::
+   :maxdepth: 10
+   
+   address_type
+   array_dynamic_type
+   array_static_type
+   base_type
+   bool_type
+   byte_type
+   contract
+   interface
+   method
+   reference
+   string_type
+   transaction
+   tuple_type
+   ufixed_type
+   uint_type

--- a/docs/algosdk/abi/interface.rst
+++ b/docs/algosdk/abi/interface.rst
@@ -1,0 +1,7 @@
+interface
+=========
+
+.. automodule:: algosdk.abi.interface
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/algosdk/abi/method.rst
+++ b/docs/algosdk/abi/method.rst
@@ -1,0 +1,7 @@
+method
+======
+
+.. automodule:: algosdk.abi.method
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/algosdk/abi/reference.rst
+++ b/docs/algosdk/abi/reference.rst
@@ -1,0 +1,7 @@
+reference
+=========
+
+.. automodule:: algosdk.abi.reference
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/algosdk/abi/string_type.rst
+++ b/docs/algosdk/abi/string_type.rst
@@ -1,0 +1,7 @@
+string_type
+===========
+
+.. automodule:: algosdk.abi.string_type
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/algosdk/abi/transaction.rst
+++ b/docs/algosdk/abi/transaction.rst
@@ -1,0 +1,7 @@
+transaction
+===========
+
+.. automodule:: algosdk.abi.transaction
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/algosdk/abi/tuple_type.rst
+++ b/docs/algosdk/abi/tuple_type.rst
@@ -1,0 +1,7 @@
+tuple_type
+==========
+
+.. automodule:: algosdk.abi.tuple_type
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/algosdk/abi/ufixed_type.rst
+++ b/docs/algosdk/abi/ufixed_type.rst
@@ -1,0 +1,7 @@
+ufixed_type
+===========
+
+.. automodule:: algosdk.abi.ufixed_type
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/algosdk/abi/uint_type.rst
+++ b/docs/algosdk/abi/uint_type.rst
@@ -1,0 +1,7 @@
+uint_type
+=========
+
+.. automodule:: algosdk.abi.uint_type
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/algosdk/atomic_transaction_composer.rst
+++ b/docs/algosdk/atomic_transaction_composer.rst
@@ -1,0 +1,7 @@
+atomic_transaction_composer
+===========================
+
+.. automodule:: algosdk.atomic_transaction_composer
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/algosdk/index.rst
+++ b/docs/algosdk/index.rst
@@ -3,8 +3,10 @@ algosdk
 .. toctree::
    :maxdepth: 10
 
+   abi/index
    account
    algod
+   atomic_transaction_composer
    auction
    constants
    encoding

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,3 @@
+sphinx==4.0.1
+sphinx-rtd-theme
 m2r2


### PR DESCRIPTION
Tentatively add the ABI package and `atomic_transaction_composer` docs to Sphinx.

I have used an ugly command line to generate the `abi` files; might have missed something.
Also, first time using `sphinx` :)