### PR TITLE
Partially fix types for atomic transaction composer

### DIFF
--- a/algosdk/atomic_transaction_composer.py
+++ b/algosdk/atomic_transaction_composer.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 import base64
 import copy
 from enum import IntEnum
-from typing import Any, List, TypeVar, Union
+from typing import Any, List, Optional, TypeVar, Union
 
 from algosdk import abi, error
 from algosdk.abi.address_type import AddressType
@@ -690,7 +690,7 @@ class ABIResult:
         tx_id: int,
         raw_value: bytes,
         return_value: Any,
-        decode_error: error,
+        decode_error: Optional[Exception],
         tx_info: dict,
     ) -> None:
         self.tx_id = tx_id


### PR DESCRIPTION
`decode_error` is now an optional Exception.

Was getting the following error from `mypy`:

> py-algorand-sdk/algosdk/atomic_transaction_composer.py|693 col 23-28 error| Module cannot be used as a type

Also, this was creating trouble when generating documentation (see https://github.com/algorand/py-algorand-sdk/pull/289)

Note that there are other warnings/issues, but decided to start small and only fix this one as it was blocking for docs.