### PR TITLE
Change min fee from constant to suggested param

### DIFF
--- a/algosdk/future/transaction.py
+++ b/algosdk/future/transaction.py
@@ -366,7 +366,7 @@ class PaymentTxn(Transaction):
         self.close_remainder_to = close_remainder_to
         if not sp.flat_fee:
             self.fee = max(
-                self.estimate_size() * self.fee, constants.min_txn_fee
+                self.estimate_size() * self.fee, sp.min_fee
             )
 
     def dictify(self):
@@ -478,7 +478,7 @@ class KeyregTxn(Transaction):
 
         if not sp.flat_fee:
             self.fee = max(
-                self.estimate_size() * self.fee, constants.min_txn_fee
+                self.estimate_size() * self.fee, sp.min_fee
             )
 
     def dictify(self):
@@ -605,7 +605,7 @@ class KeyregOnlineTxn(KeyregTxn):
             raise error.KeyregOnlineTxnInitError("votekd")
         if not sp.flat_fee:
             self.fee = max(
-                self.estimate_size() * self.fee, constants.min_txn_fee
+                self.estimate_size() * self.fee, sp.min_fee
             )
 
     @staticmethod
@@ -689,7 +689,7 @@ class KeyregOfflineTxn(KeyregTxn):
         )
         if not sp.flat_fee:
             self.fee = max(
-                self.estimate_size() * self.fee, constants.min_txn_fee
+                self.estimate_size() * self.fee, sp.min_fee
             )
 
     @staticmethod
@@ -749,7 +749,7 @@ class KeyregNonparticipatingTxn(KeyregTxn):
         )
         if not sp.flat_fee:
             self.fee = max(
-                self.estimate_size() * self.fee, constants.min_txn_fee
+                self.estimate_size() * self.fee, sp.min_fee
             )
 
     @staticmethod
@@ -884,7 +884,7 @@ class AssetConfigTxn(Transaction):
             raise error.OutOfRangeDecimalsError
         if not sp.flat_fee:
             self.fee = max(
-                self.estimate_size() * self.fee, constants.min_txn_fee
+                self.estimate_size() * self.fee, sp.min_fee
             )
 
     def dictify(self):
@@ -1239,7 +1239,7 @@ class AssetFreezeTxn(Transaction):
         self.new_freeze_state = new_freeze_state
         if not sp.flat_fee:
             self.fee = max(
-                self.estimate_size() * self.fee, constants.min_txn_fee
+                self.estimate_size() * self.fee, sp.min_fee
             )
 
     def dictify(self):
@@ -1356,7 +1356,7 @@ class AssetTransferTxn(Transaction):
         self.revocation_target = revocation_target
         if not sp.flat_fee:
             self.fee = max(
-                self.estimate_size() * self.fee, constants.min_txn_fee
+                self.estimate_size() * self.fee, sp.min_fee
             )
 
     def dictify(self):
@@ -1626,7 +1626,7 @@ class ApplicationCallTxn(Transaction):
         self.extra_pages = extra_pages
         if not sp.flat_fee:
             self.fee = max(
-                self.estimate_size() * self.fee, constants.min_txn_fee
+                self.estimate_size() * self.fee, sp.min_fee
             )
 
     @staticmethod


### PR DESCRIPTION
I do not know what peoples thoughts are about this is since I did not receive a response from #284.

This PR changes the fee calculations for Transaction classes under future.transaction so that it uses `sp.min_fee` instead of `constants.min_txn_fee` in calculations when flat_fee=false.

Rationale:
* It is more intuitive to use min_fee in the SuggestedParams which the user is actively passing into the Transaction object, rather than a hidden/hard-coded value.
* Application calls with inner transactions require a higher min-transaction fee. It is more convenient to set the value `suggested_params.min_fee *= 2` rather than configuring flat fees.
* The min-fee might change in the future, and it is better to use the value returned from the Algorand REST API than a hard-coded constant.

I tried running tests using `make docker-test` but it is excruciatingly slow for some reason, so I will think about that another time.