### PR TITLE
Link to issue for fixing local-integ tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ local-unit:
 	
 local-integ:
 	pytest test/integration/blackbox_test.py test/integration/dryrun_mixin_docs_test.py
-	# NOT WORKING: pytest test/integration/integration_test.py
+	# NOT WORKING - https://github.com/algorand/py-algorand-sdk/issues/306: pytest test/integration/integration_test.py
 
 UNITS = "@unit.abijson or @unit.algod or @unit.applications or @unit.atomic_transaction_composer or @unit.dryrun or @unit.feetest or @unit.indexer or @unit.indexer.logs or @unit.offline or @unit.rekey or @unit.transactions.keyreg or @unit.responses or @unit.responses.231 or @unit.tealsign or @unit.transactions or @unit.transactions.payment or @unit.responses.unlimited_assets or @unit.indexer.ledger_refactoring or @unit.algod.ledger_refactoring"
 cuke-unit:


### PR DESCRIPTION
Adds an inline comment link to https://github.com/algorand/py-algorand-sdk/issues/306 documenting the need to fix the broken tests.