### PR TITLE
Adding method to verify signature on SignedTransaction object

### DIFF
--- a/algosdk/future/transaction.py
+++ b/algosdk/future/transaction.py
@@ -2145,6 +2145,35 @@ class SignedTransaction:
         """
         return self.transaction.get_txid()
 
+    def verify_signature(self):
+        """
+        Verify the signature on the transaction is valid
+
+        Returns:
+            bool: whether or not the signature is valid
+        """
+
+        if self.signature is None or len(self.signature) == 0:
+            # TODO: exception?
+            return False
+
+        public_key = self.transaction.sender
+        if self.authorizing_address is not None:
+            public_key = self.authorizing_address
+
+        verify_key = VerifyKey(encoding.decode_address(public_key))
+
+        prefixed_message = constants.TXID_PREFIX + base64.b64decode(
+            encoding.msgpack_encode(self.transaction)
+        )
+        try:
+            verify_key.verify(
+                prefixed_message, base64.b64decode(self.signature)
+            )
+            return True
+        except BadSignatureError:
+            return False
+
     def dictify(self):
         od = OrderedDict()
         if self.signature:


### PR DESCRIPTION
I can do this across SDKs if this is reasonable

Should fill the need of https://github.com/algorand-devrel/community/issues/10

API is 
```py
#...
pk, sk = get_account()
pay_txn = transaction.PaymentTxn(pk, sp, rcv, 10000)
stxn = pay_txn.sign(sk)
if not stxn.verify_signature():
    print("failzore")
#...
```

