### PR TITLE
Catch TypeError and ValueError in verify functions

### DIFF
--- a/algosdk/abi/tuple_type.py
+++ b/algosdk/abi/tuple_type.py
@@ -17,7 +17,7 @@ class TupleType(ABIType):
     """
 
     def __init__(self, arg_types: List[Any]) -> None:
-        if len(arg_types) >= 2 ** 16:
+        if len(arg_types) >= 2**16:
             raise error.ABITypeError(
                 "tuple args cannot exceed a uint16: {}".format(len(arg_types))
             )
@@ -143,7 +143,7 @@ class TupleType(ABIType):
         Returns:
             bytes: encoded bytes of the tuple
         """
-        if len(self.child_types) >= (2 ** 16):
+        if len(self.child_types) >= (2**16):
             raise error.ABIEncodingError(
                 "length of tuple array should not exceed a uint16: {}".format(
                     len(self.child_types)
@@ -198,7 +198,7 @@ class TupleType(ABIType):
         for i in range(len(heads)):
             if is_dynamic_index[i]:
                 head_value = head_length + tail_curr_length
-                if head_value >= 2 ** 16:
+                if head_value >= 2**16:
                     raise error.ABIEncodingError(
                         "byte length {} should not exceed a uint16".format(
                             head_value

--- a/algosdk/abi/ufixed_type.py
+++ b/algosdk/abi/ufixed_type.py
@@ -69,7 +69,7 @@ class UfixedType(ABIType):
         """
         if (
             not isinstance(value, int)
-            or value >= (2 ** self.bit_size)
+            or value >= (2**self.bit_size)
             or value < 0
         ):
             raise error.ABIEncodingError(

--- a/algosdk/abi/uint_type.py
+++ b/algosdk/abi/uint_type.py
@@ -54,7 +54,7 @@ class UintType(ABIType):
         """
         if (
             not isinstance(value, int)
-            or value >= (2 ** self.bit_size)
+            or value >= (2**self.bit_size)
             or value < 0
         ):
             raise error.ABIEncodingError(

--- a/algosdk/future/transaction.py
+++ b/algosdk/future/transaction.py
@@ -2393,7 +2393,7 @@ class Multisig:
                 try:
                     verify_key.verify(message, subsig.signature)
                     verified_count += 1
-                except BadSignatureError:
+                except (BadSignatureError, ValueError, TypeError):
                     return False
 
         if verified_count < self.threshold:
@@ -2562,7 +2562,7 @@ class LogicSig:
             try:
                 verify_key.verify(to_sign, base64.b64decode(self.sig))
                 return True
-            except (BadSignatureError, ValueError):
+            except (BadSignatureError, ValueError, TypeError):
                 return False
 
         return self.msig.verify(to_sign)

--- a/algosdk/util.py
+++ b/algosdk/util.py
@@ -69,7 +69,7 @@ def verify_bytes(message, signature, public_key):
     try:
         verify_key.verify(prefixed_message, base64.b64decode(signature))
         return True
-    except BadSignatureError:
+    except (BadSignatureError, ValueError, TypeError):
         return False
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 .
-black==21.9b0
+black==22.3.0
 glom==20.11.0
 pytest==6.2.5
 git+https://github.com/behave/behave

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,11 @@ setuptools.setup(
     project_urls={
         "Source": "https://github.com/algorand/py-algorand-sdk",
     },
-    install_requires=["pynacl>=1.4.0,<=1.5.0", "pycryptodomex>=3.9.8,<=3.14.1", "msgpack>=1.0.2,<=1.0.3"],
+    install_requires=[
+        "pynacl>=1.4.0,<=1.5.0",
+        "pycryptodomex>=3.9.8,<=3.14.1",
+        "msgpack>=1.0.2,<=1.0.3",
+    ],
     packages=setuptools.find_packages(),
     python_requires=">=3.5",
     package_data={"": ["data/langspec.json"]},

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,9 @@ setuptools.setup(
         "Source": "https://github.com/algorand/py-algorand-sdk",
     },
     install_requires=[
-        "pynacl>=1.0.0,<=1.5.0",
-        "pycryptodomex>=3.6.0,<=3.14.1",
-        "msgpack>=1.0.0,<=1.0.3",
+        "pynacl>=1.4.0,<2",
+        "pycryptodomex>=3.6.0,<4",
+        "msgpack>=1.0.0,<2",
     ],
     packages=setuptools.find_packages(),
     python_requires=">=3.5",

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,9 @@ setuptools.setup(
         "Source": "https://github.com/algorand/py-algorand-sdk",
     },
     install_requires=[
-        "pynacl>=1.4.0,<=1.5.0",
-        "pycryptodomex>=3.9.8,<=3.14.1",
-        "msgpack>=1.0.2,<=1.0.3",
+        "pynacl",
+        "pycryptodomex>=3.6.0",
+        "msgpack",
     ],
     packages=setuptools.find_packages(),
     python_requires=">=3.5",

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,9 @@ setuptools.setup(
         "Source": "https://github.com/algorand/py-algorand-sdk",
     },
     install_requires=[
-        "pynacl",
-        "pycryptodomex>=3.6.0",
-        "msgpack",
+        "pynacl>=1.0.0,<=1.5.0",
+        "pycryptodomex>=3.6.0,<=3.14.1",
+        "msgpack>=1.0.0,<=1.0.3",
     ],
     packages=setuptools.find_packages(),
     python_requires=">=3.5",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     project_urls={
         "Source": "https://github.com/algorand/py-algorand-sdk",
     },
-    install_requires=["pynacl", "pycryptodomex>=3.6.0", "msgpack"],
+    install_requires=["pynacl>=1.4.0,<=1.5.0", "pycryptodomex>=3.9.8,<=3.14.1", "msgpack>=1.0.2,<=1.0.3"],
     packages=setuptools.find_packages(),
     python_requires=">=3.5",
     package_data={"": ["data/langspec.json"]},

--- a/test/steps/steps.py
+++ b/test/steps/steps.py
@@ -984,34 +984,34 @@ def add_rekey_to_address(context, rekey):
     context.txn.rekey_to = rekey
 
 
-@given(u'base64 encoded data to sign "{data_enc}"')
+@given('base64 encoded data to sign "{data_enc}"')
 def set_base64_encoded_data(context, data_enc):
     context.data = base64.b64decode(data_enc)
 
 
-@given(u'program hash "{contract_addr}"')
+@given('program hash "{contract_addr}"')
 def set_program_hash(context, contract_addr):
     context.address = contract_addr
 
 
-@when(u"I perform tealsign")
+@when("I perform tealsign")
 def perform_tealsign(context):
     context.sig = logic.teal_sign(context.sk, context.data, context.address)
 
 
-@then(u'the signature should be equal to "{sig_enc}"')
+@then('the signature should be equal to "{sig_enc}"')
 def check_tealsign(context, sig_enc):
     expected = base64.b64decode(sig_enc)
     assert expected == context.sig
 
 
-@given(u'base64 encoded program "{program_enc}"')
+@given('base64 encoded program "{program_enc}"')
 def set_program_hash_from_program(context, program_enc):
     program = base64.b64decode(program_enc)
     context.address = logic.address(program)
 
 
-@given(u'base64 encoded private key "{sk_enc}"')
+@given('base64 encoded private key "{sk_enc}"')
 def set_sk_from_encoded_seed(context, sk_enc):
     seed = base64.b64decode(sk_enc)
     key = SigningKey(seed)

--- a/test_unit.py
+++ b/test_unit.py
@@ -3698,7 +3698,7 @@ class TestABIEncoding(unittest.TestCase):
                 expected = val
                 self.assertEqual(actual, expected)
             # Test for the upper limit of each bit size
-            val = 2 ** uint_size - 1
+            val = 2**uint_size - 1
             uint_type = UintType(uint_size)
             actual = uint_type.encode(val)
             self.assertEqual(len(actual), uint_type.bit_size // 8)
@@ -3714,7 +3714,7 @@ class TestABIEncoding(unittest.TestCase):
             with self.assertRaises(error.ABIEncodingError) as e:
                 UintType(uint_size).encode(-1)
             with self.assertRaises(error.ABIEncodingError) as e:
-                UintType(uint_size).encode(2 ** uint_size)
+                UintType(uint_size).encode(2**uint_size)
             with self.assertRaises(error.ABIEncodingError) as e:
                 UintType(uint_size).decode("ZZZZ")
             with self.assertRaises(error.ABIEncodingError) as e:
@@ -3737,7 +3737,7 @@ class TestABIEncoding(unittest.TestCase):
                     expected = val
                     self.assertEqual(actual, expected)
             # Test for the upper limit of each bit size
-            val = 2 ** ufixed_size - 1
+            val = 2**ufixed_size - 1
             ufixed_type = UfixedType(ufixed_size, precision)
             actual = ufixed_type.encode(val)
             self.assertEqual(len(actual), ufixed_type.bit_size // 8)
@@ -3753,7 +3753,7 @@ class TestABIEncoding(unittest.TestCase):
             with self.assertRaises(error.ABIEncodingError) as e:
                 UfixedType(ufixed_size, 10).encode(-1)
             with self.assertRaises(error.ABIEncodingError) as e:
-                UfixedType(ufixed_size, 10).encode(2 ** ufixed_size)
+                UfixedType(ufixed_size, 10).encode(2**ufixed_size)
             with self.assertRaises(error.ABIEncodingError) as e:
                 UfixedType(ufixed_size, 10).decode("ZZZZ")
             with self.assertRaises(error.ABIEncodingError) as e:

--- a/test_unit.py
+++ b/test_unit.py
@@ -2127,6 +2127,8 @@ class TestSignBytes(unittest.TestCase):
         intarray[0] = (intarray[0] + 1) % 256
         changed_message = bytes(intarray)
         self.assertFalse(util.verify_bytes(changed_message, signature, pk))
+        # Check that wrong number of bytes returns false in verify function.
+        self.assertFalse(util.verify_bytes(bytes(), signature, pk))
 
 
 class TestLogic(unittest.TestCase):
@@ -2700,7 +2702,10 @@ class TestLogicSigAccount(unittest.TestCase):
         sigLsigAccount = encoding.future_msgpack_decode(sigEncoded)
         self.assertEqual(sigLsigAccount.verify(), True)
 
-        sigLsigAccount.lsig.sig = "AQ=="  # wrong sig
+        sigLsigAccount.lsig.sig = "AQ=="  # wrong length of bytes
+        self.assertEqual(sigLsigAccount.verify(), False)
+
+        sigLsigAccount.lsig.sig = 123  # wrong type (not bytes)
         self.assertEqual(sigLsigAccount.verify(), False)
 
         msigEncoded = "gaRsc2lng6NhcmeSxAEBxAICA6FsxAUBIAEBIqRtc2lng6ZzdWJzaWeTgqJwa8QgG37AsEvqYbeWkJfmy/QH4QinBTUdC8mKvrEiCairgXihc8RASRO4BdGefywQgPYzfhhUp87q7hDdvRNlhL+Tt18wYxWRyiMM7e8j0XQbUp2w/+83VNZG9LVh/Iu8LXtOY1y9AoKicGvEIAljMglTc4nwdWcRdzmRx9A+G3PIxPUr9q/wGqJc+cJxoXPEQGS8VdvtkaJB1Cq2YPfhSrmZmlKzsXFYzvw/T+fLIkEUrak9XoQFAgoXpmmDAyJOhqOLajbFVL4gUP/T7qizBAmBonBrxCDn8PhNBoEd+fMcjYeLEVX0Zx1RoYXCAJCGZ/RJWHBooaN0aHICoXYB"


### PR DESCRIPTION
`pynacl`'s `VerifyKey()` can now return a [`TypeError` or `ValueError`](https://github.com/pyca/pynacl/blob/b3f6c320569d858ba61d4bdf2ac788564528c1c9/src/nacl/signing.py#L98) ([related PR](https://github.com/pyca/pynacl/pull/600/files)). Our SDK should reflect this change by catching those errors as well, or users may encounter an unexpected exception. 

Picked some major release versions and set that as boundaries. Hopefully users are using `venv` or `conda` as well...
* [pynacl](https://github.com/pyca/pynacl/tags)
* [msgpack](https://github.com/msgpack/msgpack-python/releases)
* [pycryptodomex](https://github.com/Legrandin/pycryptodome/releases)

Also added the `black` formatter updates so CI can run normally.

I didn't change the v1 `transaction` methods, but the problem is there as well (I hope no one uses them because we haven't updated them for a very long time). 