### PR TITLE
adding condition for allowing rcv to be none if close to is set

### DIFF
--- a/algosdk/constants.py
+++ b/algosdk/constants.py
@@ -89,6 +89,9 @@ LOGIC_SIG_MAX_COST = 20000
 LOGIC_SIG_MAX_SIZE = 1000
 """int: max size of a teal program and its arguments in bytes"""
 
+ZERO_ADDRESS = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ"
+"""str: algorand encoded address of 32 zero bytes"""
+
 # for backward compatibility:
 kmd_auth_header = KMD_AUTH_HEADER
 algod_auth_header = ALGOD_AUTH_HEADER
@@ -127,3 +130,4 @@ tx_group_limit = TX_GROUP_LIMIT
 max_asset_decimals = MAX_ASSET_DECIMALS
 logic_sig_max_cost = LOGIC_SIG_MAX_COST
 logic_sig_max_size = LOGIC_SIG_MAX_SIZE
+zero_address = ZERO_ADDRESS

--- a/algosdk/constants.py
+++ b/algosdk/constants.py
@@ -130,4 +130,3 @@ tx_group_limit = TX_GROUP_LIMIT
 max_asset_decimals = MAX_ASSET_DECIMALS
 logic_sig_max_cost = LOGIC_SIG_MAX_COST
 logic_sig_max_size = LOGIC_SIG_MAX_SIZE
-zero_address = ZERO_ADDRESS

--- a/algosdk/future/transaction.py
+++ b/algosdk/future/transaction.py
@@ -13,6 +13,7 @@ from ..v2client import algod, models
 from nacl.signing import SigningKey, VerifyKey
 from nacl.exceptions import BadSignatureError
 
+# TODO: cant use encoding.encode_address(bytes(32)) because of circular import?
 ZERO_ADDRESS = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ"
 
 

--- a/algosdk/future/transaction.py
+++ b/algosdk/future/transaction.py
@@ -13,9 +13,6 @@ from ..v2client import algod, models
 from nacl.signing import SigningKey, VerifyKey
 from nacl.exceptions import BadSignatureError
 
-# TODO: cant use encoding.encode_address(bytes(32)) because of circular import?
-ZERO_ADDRESS = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ"
-
 
 class SuggestedParams:
     """
@@ -361,7 +358,7 @@ class PaymentTxn(Transaction):
         if receiver:
             self.receiver = receiver
         elif close_remainder_to is not None:
-            self.receiver = ZERO_ADDRESS
+            self.receiver = constants.ZERO_ADDRESS
         else:
             raise error.ZeroAddressError
 
@@ -1352,7 +1349,7 @@ class AssetTransferTxn(Transaction):
         if receiver:
             self.receiver = receiver
         elif close_assets_to is not None:
-            self.receiver = ZERO_ADDRESS
+            self.receiver = constants.ZERO_ADDRESS
         else:
             raise error.ZeroAddressError
 

--- a/algosdk/future/transaction.py
+++ b/algosdk/future/transaction.py
@@ -357,8 +357,6 @@ class PaymentTxn(Transaction):
         )
         if receiver:
             self.receiver = receiver
-        elif close_remainder_to and not amt:
-            self.receiver = constants.ZERO_ADDRESS
         else:
             raise error.ZeroAddressError
 
@@ -396,7 +394,7 @@ class PaymentTxn(Transaction):
             "amt": d["amt"] if "amt" in d else 0,
             "receiver": encoding.encode_address(d["rcv"])
             if "rcv" in d
-            else None,
+            else constants.ZERO_ADDRESS,
         }
         return args
 
@@ -1348,8 +1346,6 @@ class AssetTransferTxn(Transaction):
         )
         if receiver:
             self.receiver = receiver
-        elif close_assets_to and not amt:
-            self.receiver = constants.ZERO_ADDRESS
         else:
             raise error.ZeroAddressError
 
@@ -1391,7 +1387,7 @@ class AssetTransferTxn(Transaction):
         args = {
             "receiver": encoding.encode_address(d["arcv"])
             if "arcv" in d
-            else None,
+            else constants.ZERO_ADDRESS,
             "amt": d["aamt"] if "aamt" in d else 0,
             "index": d["xaid"] if "xaid" in d else None,
             "close_assets_to": encoding.encode_address(d["aclose"])

--- a/algosdk/future/transaction.py
+++ b/algosdk/future/transaction.py
@@ -13,6 +13,8 @@ from ..v2client import algod, models
 from nacl.signing import SigningKey, VerifyKey
 from nacl.exceptions import BadSignatureError
 
+ZERO_ADDRESS = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ"
+
 
 class SuggestedParams:
     """
@@ -357,6 +359,8 @@ class PaymentTxn(Transaction):
         )
         if receiver:
             self.receiver = receiver
+        elif close_remainder_to is not None:
+            self.receiver = ZERO_ADDRESS
         else:
             raise error.ZeroAddressError
 
@@ -1346,8 +1350,11 @@ class AssetTransferTxn(Transaction):
         )
         if receiver:
             self.receiver = receiver
+        elif close_assets_to is not None:
+            self.receiver = ZERO_ADDRESS
         else:
             raise error.ZeroAddressError
+
         self.amount = amt
         if (not isinstance(self.amount, int)) or self.amount < 0:
             raise error.WrongAmountType

--- a/algosdk/future/transaction.py
+++ b/algosdk/future/transaction.py
@@ -357,7 +357,7 @@ class PaymentTxn(Transaction):
         )
         if receiver:
             self.receiver = receiver
-        elif close_remainder_to is not None:
+        elif close_remainder_to and not amt:
             self.receiver = constants.ZERO_ADDRESS
         else:
             raise error.ZeroAddressError
@@ -1348,7 +1348,7 @@ class AssetTransferTxn(Transaction):
         )
         if receiver:
             self.receiver = receiver
-        elif close_assets_to is not None:
+        elif close_assets_to and not amt:
             self.receiver = constants.ZERO_ADDRESS
         else:
             raise error.ZeroAddressError

--- a/algosdk/testing/dryrun.py
+++ b/algosdk/testing/dryrun.py
@@ -18,7 +18,6 @@ from algosdk.v2client.models import (
 )
 
 
-ZERO_ADDRESS = encode_address(bytes(32))
 PRINTABLE = frozenset(string.printable)
 
 
@@ -33,7 +32,7 @@ class LSig:
 class App:
     """Application program parameters"""
 
-    creator: str = ZERO_ADDRESS
+    creator: str = transaction.ZERO_ADDRESS
     round: int = None
     app_idx: int = 0
     on_complete: int = 0
@@ -54,7 +53,7 @@ class DryrunTestCaseMixin:
         prog_drr_txns,
         lsig=None,
         app=None,
-        sender=ZERO_ADDRESS,
+        sender=transaction.ZERO_ADDRESS,
         txn_index=None,
         msg=None,
     ):
@@ -90,7 +89,7 @@ class DryrunTestCaseMixin:
         prog_drr_txns,
         lsig=None,
         app=None,
-        sender=ZERO_ADDRESS,
+        sender=transaction.ZERO_ADDRESS,
         txn_index=None,
         msg=None,
     ):
@@ -127,7 +126,7 @@ class DryrunTestCaseMixin:
         status,
         lsig=None,
         app=None,
-        sender=ZERO_ADDRESS,
+        sender=transaction.ZERO_ADDRESS,
         txn_index=None,
         msg=None,
     ):
@@ -194,7 +193,7 @@ class DryrunTestCaseMixin:
         prog_drr_txns,
         lsig=None,
         app=None,
-        sender=ZERO_ADDRESS,
+        sender=transaction.ZERO_ADDRESS,
         txn_index=None,
         msg=None,
     ):
@@ -225,7 +224,7 @@ class DryrunTestCaseMixin:
         pattern=None,
         lsig=None,
         app=None,
-        sender=ZERO_ADDRESS,
+        sender=transaction.ZERO_ADDRESS,
         txn_index=None,
         msg=None,
     ):
@@ -258,7 +257,7 @@ class DryrunTestCaseMixin:
         prog_drr_txns,
         delta_value,
         app=None,
-        sender=ZERO_ADDRESS,
+        sender=transaction.ZERO_ADDRESS,
         txn_index=None,
         msg=None,
     ):
@@ -326,7 +325,7 @@ class DryrunTestCaseMixin:
         addr,
         delta_value,
         app=None,
-        sender=ZERO_ADDRESS,
+        sender=transaction.ZERO_ADDRESS,
         txn_index=None,
         msg=None,
     ):
@@ -398,7 +397,7 @@ class DryrunTestCaseMixin:
             self._fail(msg)
 
     def dryrun_request(
-        self, program, lsig=None, app=None, sender=ZERO_ADDRESS
+        self, program, lsig=None, app=None, sender=transaction.ZERO_ADDRESS
     ):
         """
         Helper function for creation DryrunRequest and making the REST request
@@ -463,7 +462,7 @@ class DryrunTestCaseMixin:
     @staticmethod
     def default_address():
         """Helper function returning default zero addr"""
-        return ZERO_ADDRESS
+        return transaction.ZERO_ADDRESS
 
     def _dryrun_request(self, prog_drr_txns, lsig, app, sender):
         """
@@ -478,7 +477,11 @@ class DryrunTestCaseMixin:
         return drr
 
     def _checked_request(
-        self, prog_drr_txns, lsig=None, app=None, sender=ZERO_ADDRESS
+        self,
+        prog_drr_txns,
+        lsig=None,
+        app=None,
+        sender=transaction.ZERO_ADDRESS,
     ):
         """
         Helper function to make a dryrun request and perform basic validation
@@ -504,7 +507,7 @@ class Helper:
 
     @classmethod
     def build_dryrun_request(
-        cls, program, lsig=None, app=None, sender=ZERO_ADDRESS
+        cls, program, lsig=None, app=None, sender=transaction.ZERO_ADDRESS
     ):
         """
         Helper function for creation DryrunRequest object from a program.

--- a/algosdk/testing/dryrun.py
+++ b/algosdk/testing/dryrun.py
@@ -4,7 +4,7 @@ import string
 from dataclasses import dataclass
 from typing import List, Union
 
-from algosdk.constants import payment_txn, appcall_txn
+from algosdk.constants import payment_txn, appcall_txn, zero_address
 from algosdk.future import transaction
 from algosdk.encoding import encode_address, msgpack_encode
 from algosdk.v2client.models import (
@@ -32,7 +32,7 @@ class LSig:
 class App:
     """Application program parameters"""
 
-    creator: str = transaction.ZERO_ADDRESS
+    creator: str = zero_address
     round: int = None
     app_idx: int = 0
     on_complete: int = 0
@@ -53,7 +53,7 @@ class DryrunTestCaseMixin:
         prog_drr_txns,
         lsig=None,
         app=None,
-        sender=transaction.ZERO_ADDRESS,
+        sender=zero_address,
         txn_index=None,
         msg=None,
     ):
@@ -89,7 +89,7 @@ class DryrunTestCaseMixin:
         prog_drr_txns,
         lsig=None,
         app=None,
-        sender=transaction.ZERO_ADDRESS,
+        sender=zero_address,
         txn_index=None,
         msg=None,
     ):
@@ -126,7 +126,7 @@ class DryrunTestCaseMixin:
         status,
         lsig=None,
         app=None,
-        sender=transaction.ZERO_ADDRESS,
+        sender=zero_address,
         txn_index=None,
         msg=None,
     ):
@@ -193,7 +193,7 @@ class DryrunTestCaseMixin:
         prog_drr_txns,
         lsig=None,
         app=None,
-        sender=transaction.ZERO_ADDRESS,
+        sender=zero_address,
         txn_index=None,
         msg=None,
     ):
@@ -224,7 +224,7 @@ class DryrunTestCaseMixin:
         pattern=None,
         lsig=None,
         app=None,
-        sender=transaction.ZERO_ADDRESS,
+        sender=zero_address,
         txn_index=None,
         msg=None,
     ):
@@ -257,7 +257,7 @@ class DryrunTestCaseMixin:
         prog_drr_txns,
         delta_value,
         app=None,
-        sender=transaction.ZERO_ADDRESS,
+        sender=zero_address,
         txn_index=None,
         msg=None,
     ):
@@ -325,7 +325,7 @@ class DryrunTestCaseMixin:
         addr,
         delta_value,
         app=None,
-        sender=transaction.ZERO_ADDRESS,
+        sender=zero_address,
         txn_index=None,
         msg=None,
     ):
@@ -397,7 +397,7 @@ class DryrunTestCaseMixin:
             self._fail(msg)
 
     def dryrun_request(
-        self, program, lsig=None, app=None, sender=transaction.ZERO_ADDRESS
+        self, program, lsig=None, app=None, sender=zero_address
     ):
         """
         Helper function for creation DryrunRequest and making the REST request
@@ -462,7 +462,7 @@ class DryrunTestCaseMixin:
     @staticmethod
     def default_address():
         """Helper function returning default zero addr"""
-        return transaction.ZERO_ADDRESS
+        return zero_address
 
     def _dryrun_request(self, prog_drr_txns, lsig, app, sender):
         """
@@ -481,7 +481,7 @@ class DryrunTestCaseMixin:
         prog_drr_txns,
         lsig=None,
         app=None,
-        sender=transaction.ZERO_ADDRESS,
+        sender=zero_address,
     ):
         """
         Helper function to make a dryrun request and perform basic validation
@@ -507,7 +507,7 @@ class Helper:
 
     @classmethod
     def build_dryrun_request(
-        cls, program, lsig=None, app=None, sender=transaction.ZERO_ADDRESS
+        cls, program, lsig=None, app=None, sender=zero_address
     ):
         """
         Helper function for creation DryrunRequest object from a program.

--- a/algosdk/testing/dryrun.py
+++ b/algosdk/testing/dryrun.py
@@ -4,7 +4,7 @@ import string
 from dataclasses import dataclass
 from typing import List, Union
 
-from algosdk.constants import payment_txn, appcall_txn, zero_address
+from algosdk.constants import payment_txn, appcall_txn, ZERO_ADDRESS
 from algosdk.future import transaction
 from algosdk.encoding import encode_address, msgpack_encode
 from algosdk.v2client.models import (
@@ -32,7 +32,7 @@ class LSig:
 class App:
     """Application program parameters"""
 
-    creator: str = zero_address
+    creator: str = ZERO_ADDRESS
     round: int = None
     app_idx: int = 0
     on_complete: int = 0
@@ -53,7 +53,7 @@ class DryrunTestCaseMixin:
         prog_drr_txns,
         lsig=None,
         app=None,
-        sender=zero_address,
+        sender=ZERO_ADDRESS,
         txn_index=None,
         msg=None,
     ):
@@ -89,7 +89,7 @@ class DryrunTestCaseMixin:
         prog_drr_txns,
         lsig=None,
         app=None,
-        sender=zero_address,
+        sender=ZERO_ADDRESS,
         txn_index=None,
         msg=None,
     ):
@@ -126,7 +126,7 @@ class DryrunTestCaseMixin:
         status,
         lsig=None,
         app=None,
-        sender=zero_address,
+        sender=ZERO_ADDRESS,
         txn_index=None,
         msg=None,
     ):
@@ -193,7 +193,7 @@ class DryrunTestCaseMixin:
         prog_drr_txns,
         lsig=None,
         app=None,
-        sender=zero_address,
+        sender=ZERO_ADDRESS,
         txn_index=None,
         msg=None,
     ):
@@ -224,7 +224,7 @@ class DryrunTestCaseMixin:
         pattern=None,
         lsig=None,
         app=None,
-        sender=zero_address,
+        sender=ZERO_ADDRESS,
         txn_index=None,
         msg=None,
     ):
@@ -257,7 +257,7 @@ class DryrunTestCaseMixin:
         prog_drr_txns,
         delta_value,
         app=None,
-        sender=zero_address,
+        sender=ZERO_ADDRESS,
         txn_index=None,
         msg=None,
     ):
@@ -325,7 +325,7 @@ class DryrunTestCaseMixin:
         addr,
         delta_value,
         app=None,
-        sender=zero_address,
+        sender=ZERO_ADDRESS,
         txn_index=None,
         msg=None,
     ):
@@ -397,7 +397,7 @@ class DryrunTestCaseMixin:
             self._fail(msg)
 
     def dryrun_request(
-        self, program, lsig=None, app=None, sender=zero_address
+        self, program, lsig=None, app=None, sender=ZERO_ADDRESS
     ):
         """
         Helper function for creation DryrunRequest and making the REST request
@@ -462,7 +462,7 @@ class DryrunTestCaseMixin:
     @staticmethod
     def default_address():
         """Helper function returning default zero addr"""
-        return zero_address
+        return ZERO_ADDRESS
 
     def _dryrun_request(self, prog_drr_txns, lsig, app, sender):
         """
@@ -481,7 +481,7 @@ class DryrunTestCaseMixin:
         prog_drr_txns,
         lsig=None,
         app=None,
-        sender=zero_address,
+        sender=ZERO_ADDRESS,
     ):
         """
         Helper function to make a dryrun request and perform basic validation
@@ -507,7 +507,7 @@ class Helper:
 
     @classmethod
     def build_dryrun_request(
-        cls, program, lsig=None, app=None, sender=zero_address
+        cls, program, lsig=None, app=None, sender=ZERO_ADDRESS
     ):
         """
         Helper function for creation DryrunRequest object from a program.

--- a/test_unit.py
+++ b/test_unit.py
@@ -1942,6 +1942,30 @@ class TestMsgpack(unittest.TestCase):
             paytxn, encoding.msgpack_encode(encoding.msgpack_decode(paytxn))
         )
 
+    def test_payment_txn_future(self):
+        paytxn = (
+            "iKVjbG9zZcQgYMak0FPHfqBp4So5wS5p7g+O4rLkqwo/ILSjXWQVKpGjZmVlzQPoom"
+            "Z2KqNnZW6qc2FuZG5ldC12MaJnaMQgNCTHAIMgeYC+4MCSbMinkrlsgtRD6jhfJEXz"
+            "IP3mH9SibHbNBBKjc25kxCARM5ng7Z1RkubT9fUef5nT9w0MGQKRGbwgOva8/tx3qqR"
+            "0eXBlo3BheQ=="
+        )
+        self.assertEqual(
+            paytxn,
+            encoding.msgpack_encode(encoding.future_msgpack_decode(paytxn)),
+        )
+
+    def test_asset_xfer_txn_future(self):
+        axfer = (
+            "iaZhY2xvc2XEIGDGpNBTx36gaeEqOcEuae4PjuKy5KsKPyC0o11kFSqRo2ZlZc0D6KJmdi"
+            "qjZ2VuqnNhbmRuZXQtdjGiZ2jEIDQkxwCDIHmAvuDAkmzIp5K5bILUQ+o4XyRF8yD95h/U"
+            "omx2zQQSo3NuZMQgETOZ4O2dUZLm0/X1Hn+Z0/cNDBkCkRm8IDr2vP7cd6qkdHlwZaVheGZ"
+            "lcqR4YWlkCg=="
+        )
+        self.assertEqual(
+            axfer,
+            encoding.msgpack_encode(encoding.future_msgpack_decode(axfer)),
+        )
+
     def test_multisig_txn(self):
         msigtxn = (
             "gqRtc2lng6ZzdWJzaWeSgqJwa8Qg1ke3gkLuR0MUN/Ku0oyiRVIm9P1QFDaiEhT5v"


### PR DESCRIPTION
closes #316 

This should still raise a useful error in the case that close to is _also_ zero since that is likely user error.

