### PR TITLE
Consistently reference `pip3` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Alternatively, choose a [distribution file](https://pypi.org/project/py-algorand
 
 Install dependencies
 
-- `pip install -r requirements.txt`
+- `pip3 install -r requirements.txt`
 
 Run tests
 


### PR DESCRIPTION
Addresses README inconsistency between `pip` and `pip3` by normalizing on `pip3`. 