### PR TITLE
Illustrate test fix by pointing algorand-sdk-testing to test branch

### DIFF
--- a/run_integration.sh
+++ b/run_integration.sh
@@ -7,7 +7,7 @@ pushd $rootdir
 
 # Reset test harness
 rm -rf test-harness
-git clone --single-branch --branch master https://github.com/algorand/algorand-sdk-testing.git test-harness
+git clone --single-branch --branch fix_abi_feature_test https://github.com/algorand/algorand-sdk-testing.git test-harness
 
 ## Copy feature files into the project resources
 mkdir -p test/features


### PR DESCRIPTION
Demonstrates proof that https://github.com/algorand/algorand-sdk-testing/pull/172 is fixed by referencing the branch.

Here's a prior build illustrating the error:  https://app.circleci.com/pipelines/github/algorand/py-algorand-sdk/483/workflows/91f9325d-ccc6-4085-996c-60d254881342/jobs/1028.

I plan to close the PR once https://github.com/algorand/algorand-sdk-testing/pull/172 is merged.