### PR TITLE
Fix docs by providing root requirements.txt

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,6 @@ sphinx:
 
 python:
    install:
-    requirements:
-      - requirements.txt
-      - docs/requirements.txt
+     requirements:
+       - requirements.txt
+       - docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,5 @@ sphinx:
 
 python:
    install:
-     requirements:
-       - requirements.txt
-       - docs/requirements.txt
+     - requirements: requirements.txt
+     - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,4 +12,6 @@ sphinx:
 
 python:
    install:
-   - requirements: docs/requirements.txt
+    requirements:
+      - requirements.txt
+      - docs/requirements.txt


### PR DESCRIPTION
Attempts to fix docs since v1.13.0 by supplying missing dependencies.

v1.13.0 readthedocs build (https://readthedocs.org/api/v2/build/16801913.txt) shows errors (that don't fail the build) for a missing msgpack dependency:

```
WARNING: autodoc: failed to import module 'abi.address_type' from module 'algosdk'; the following exception was raised:
No module named 'msgpack'
```

These errors do _not_ appear in v1.12.0 build:  https://readthedocs.org/api/v2/build/16801915.txt.