### PR TITLE
Implement new step asserting that AtomicTransactionComposer's attempt to add a method can fail with a particular error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-UNITS = "@unit.abijson or @unit.algod or @unit.algod.ledger_refactoring or @unit.applications or @unit.atomic_transaction_composer or @unit.dryrun or @unit.dryrun.trace.application or @unit.feetest or @unit.indexer or @unit.indexer.ledger_refactoring or @unit.indexer.logs or @unit.offline or @unit.rekey or @unit.transactions.keyreg or @unit.responses or @unit.responses.231 or @unit.tealsign or @unit.transactions or @unit.transactions.payment or @unit.responses.unlimited_assets"
+UNITS = "@unit.abijson or @unit.algod or @unit.algod.ledger_refactoring or @unit.applications or  @unit.atc_method_args or @unit.atomic_transaction_composer or @unit.dryrun or @unit.dryrun.trace.application or @unit.feetest or @unit.indexer or @unit.indexer.ledger_refactoring or @unit.indexer.logs or @unit.offline or @unit.rekey or @unit.transactions.keyreg or @unit.responses or @unit.responses.231 or @unit.tealsign or @unit.transactions or @unit.transactions.payment or @unit.responses.unlimited_assets"
 unit:
 	behave --tags=$(UNITS) test -f progress2
 

--- a/run_integration.sh
+++ b/run_integration.sh
@@ -7,7 +7,7 @@ pushd $rootdir
 
 # Reset test harness
 rm -rf test-harness
-git clone --single-branch --branch master https://github.com/algorand/algorand-sdk-testing.git test-harness
+git clone --single-branch --branch abi-too-many-args https://github.com/algorand/algorand-sdk-testing.git test-harness
 
 ## Copy feature files into the project resources
 mkdir -p test/features

--- a/run_integration.sh
+++ b/run_integration.sh
@@ -7,7 +7,7 @@ pushd $rootdir
 
 # Reset test harness
 rm -rf test-harness
-git clone --single-branch --branch abi-too-many-args https://github.com/algorand/algorand-sdk-testing.git test-harness
+git clone --single-branch --branch master https://github.com/algorand/algorand-sdk-testing.git test-harness
 
 ## Copy feature files into the project resources
 mkdir -p test/features

--- a/test/steps/application_v2_steps.py
+++ b/test/steps/application_v2_steps.py
@@ -681,6 +681,11 @@ def abi_method_adder(
         assert re.search(
             exception_regex, str(atce)
         ), f"{atce} did not satisfy the expected regular expression {exception_regex}"
+        return
+
+    assert (
+        exception_regex == "none"
+    ), f"should have encountered an AtomicTransactionComposerError satisfying the regex pattern {exception_regex}, but no such exception has been detected"
 
 
 @step(

--- a/test/steps/application_v2_steps.py
+++ b/test/steps/application_v2_steps.py
@@ -610,7 +610,7 @@ def abi_method_adder(
     local_ints=None,
     extra_pages=None,
     force_unique_transactions=False,
-    exception_regex="none",
+    exception_key="none",
 ):
     if account_type == "transient":
         sender = context.transient_pk
@@ -675,30 +675,40 @@ def abi_method_adder(
         )
     except AtomicTransactionComposerError as atce:
         assert (
-            exception_regex != "none"
+            exception_key != "none"
         ), f"cucumber step asserted that no exception resulted, but the following exception actually occurred: {atce}"
 
-        assert re.search(
-            exception_regex, str(atce)
-        ), f"{atce} did not satisfy the expected regular expression {exception_regex}"
+        arglen_exception = "argument_count_mismatch"
+        known_exception_keys = [arglen_exception]
+        assert (
+            exception_key in known_exception_keys
+        ), f"encountered exception key '{exception_key}' which is not in known set: {known_exception_keys}"
+
+        if exception_key == arglen_exception:
+            exception_msg = (
+                "number of method arguments do not match the method signature"
+            )
+            assert exception_msg in str(
+                atce
+            ), f"expected argument count mismatch error such as '{exception_msg}' but got the following instead: {atce}"
         return
 
     assert (
-        exception_regex == "none"
-    ), f"should have encountered an AtomicTransactionComposerError satisfying the regex pattern {exception_regex}, but no such exception has been detected"
+        exception_key == "none"
+    ), f"should have encountered an AtomicTransactionComposerError keyed by '{exception_key}', but no such exception has been detected"
 
 
 @step(
-    'I add a method call with the {account_type} account, the current application, suggested params, on complete "{operation}", current transaction signer, current method arguments; any resulting exception satisfies the regex "{exception_regex}".'
+    'I add a method call with the {account_type} account, the current application, suggested params, on complete "{operation}", current transaction signer, current method arguments; any resulting exception has key "{exception_key}".'
 )
 def add_abi_method_call_with_exception(
-    context, account_type, operation, exception_regex
+    context, account_type, operation, exception_key
 ):
     abi_method_adder(
         context,
         account_type,
         operation,
-        exception_regex=exception_regex,
+        exception_key=exception_key,
     )
 
 

--- a/test/steps/application_v2_steps.py
+++ b/test/steps/application_v2_steps.py
@@ -537,9 +537,7 @@ def add_transaction_to_composer(context):
     )
 
 
-def process_abi_args(context, method, arg_tokens, erase_empty_tokens=True):
-    if erase_empty_tokens:
-        arg_tokens = [tok for tok in arg_tokens if tok]
+def process_abi_args(context, method, arg_tokens):
     method_args = []
     for arg_index, arg_token in enumerate(arg_tokens):
         if arg_index >= len(method.args):
@@ -588,7 +586,7 @@ def append_txn_to_method_args(context):
 )
 def append_app_args_to_method_args(context, method_args):
     # Returns a list of ABI method arguments
-    app_args = method_args.split(",")
+    app_args = method_args.split(",") if method_args else []
     context.method_args += app_args
 
 

--- a/test/steps/other_v2_steps.py
+++ b/test/steps/other_v2_steps.py
@@ -604,7 +604,7 @@ def txns_by_addr(
 @when(
     'we make a Lookup Account Transactions call against account "{account:MaybeString}" with NotePrefix "{notePrefixB64:MaybeString}" TxType "{txType:MaybeString}" SigType "{sigType:MaybeString}" txid "{txid:MaybeString}" round {block} minRound {minRound} maxRound {maxRound} limit {limit} beforeTime "{beforeTime:MaybeString}" afterTime "{afterTime:MaybeString}" currencyGreaterThan {currencyGreaterThan} currencyLessThan {currencyLessThan} assetIndex {index}'
 )
-def txns_by_addr(
+def txns_by_addr2(
     context,
     account,
     notePrefixB64,
@@ -1404,27 +1404,6 @@ def algod_v2_client_at_host_port_and_token(context, host, port, token):
 def algod_v2_client(context):
     algod_address = "http://localhost" + ":" + str(algod_port)
     context.app_acl = algod.AlgodClient(daemon_token, algod_address)
-
-
-@step(
-    'I sign and submit the transaction, saving the txid. If there is an error it is "{error_string:MaybeString}".'
-)
-def sign_submit_save_txid_with_error(context, error_string):
-    try:
-        signed_app_transaction = context.app_transaction.sign(
-            context.transient_sk
-        )
-        context.app_txid = context.app_acl.send_transaction(
-            signed_app_transaction
-        )
-    except Exception as e:
-        if not error_string or error_string not in str(e):
-            raise RuntimeError(
-                "error string "
-                + error_string
-                + " not in actual error "
-                + str(e)
-            )
 
 
 @when('I compile a teal program "{program}"')


### PR DESCRIPTION
# Implementing the following step:

>  I add a method call with the signing account, the current application, suggested params, on complete "noop", current transaction signer, current method arguments; any resulting exception has key "{none-or-exception-key}".

## Related Issues and PR's
* https://github.com/algorand/algorand-sdk-testing/pull/190
* https://github.com/algorand/algorand-sdk-testing/pull/189