### PR TITLE
bug-fix: add check to desc so we dont output null if undefined

### DIFF
--- a/algosdk/abi/contract.py
+++ b/algosdk/abi/contract.py
@@ -47,8 +47,9 @@ class Contract:
         d = {}
         d["name"] = self.name
         d["methods"] = [m.dictify() for m in self.methods]
-        d["desc"] = self.desc
         d["networks"] = {k: v.dictify() for k, v in self.networks.items()}
+        if self.desc is not None:
+            d["desc"] = self.desc
         return d
 
     @staticmethod


### PR DESCRIPTION
This seems to choke the js-sdk which is expecting `string | undefined`

When there is a `None` in the dict, the json dumped includes `null`

```
>>> x = {'z':None}
>>> import json
>>> json.dumps(x)
'{"z": null}'
```

Other dictify methods have checks for this (Method/Args)