### PR TITLE
Bug-fix: Pass verbosity through to testing harness

### DIFF
--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 # Configs for testing repo download:
 SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
-SDK_TESTING_BRANCH="feature/box-storage"
+SDK_TESTING_BRANCH="bugfix-channel-v-source"
 SDK_TESTING_HARNESS="test-harness"
 
 VERBOSE_HARNESS=1

--- a/.test-env
+++ b/.test-env
@@ -3,7 +3,7 @@ SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
 SDK_TESTING_BRANCH="bugfix-channel-v-source"
 SDK_TESTING_HARNESS="test-harness"
 
-VERBOSE_HARNESS=1
+VERBOSE_HARNESS=0
 
 # WARNING: If set to 1, new features will be LOST when downloading the test harness.
 # REGARDLESS: modified features are ALWAYS overwritten.

--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 # Configs for testing repo download:
 SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
-SDK_TESTING_BRANCH="bugfix-channel-v-source"
+SDK_TESTING_BRANCH="master"
 SDK_TESTING_HARNESS="test-harness"
 
 VERBOSE_HARNESS=0

--- a/.test-env
+++ b/.test-env
@@ -1,9 +1,9 @@
 # Configs for testing repo download:
 SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
-SDK_TESTING_BRANCH="master"
+SDK_TESTING_BRANCH="feature/box-storage"
 SDK_TESTING_HARNESS="test-harness"
 
-VERBOSE_HARNESS=0
+VERBOSE_HARNESS=1
 
 # WARNING: If set to 1, new features will be LOST when downloading the test harness.
 # REGARDLESS: modified features are ALWAYS overwritten.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Run `$ pip3 install py-algorand-sdk` to install the package.
 Alternatively, choose a [distribution file](https://pypi.org/project/py-algorand-sdk/#files), and run `$ pip3 install [file name]`.
 
 ## Supported Python versions
+
 py-algorand-sdk's minimum Python version policy attempts to balance several constraints.
+
 * Make it easy for the community to use py-algorand-sdk by minimizing or excluding the need to customize Python installations.
 * Provide maintainers with access to newer language features that produce more robust software.
 
@@ -22,6 +24,7 @@ Given these constraints, the minimum Python version policy is:
 Target Python version on newest [Ubuntu LTS](https://wiki.ubuntu.com/Releases) released >= 6 months ago.
 
 The rationale is:
+
 * If a major Linux OS distribution bumps a Python version, then it's sufficiently available to the community for us to upgrade.
 * The 6 month time buffer ensures we delay upgrades until the community starts using a recently released LTS version.
 
@@ -29,15 +32,19 @@ The rationale is:
 
 Install dependencies
 
-- `pip3 install -r requirements.txt`
+* `pip3 install -r requirements.txt`
 
 Run tests
 
-- `make docker-test`
+* `make docker-test`
+
+Set up the Algorand Sandbox based test-harness without running the tests
+
+* `make harness`
 
 Format code:
 
-- `black .`
+* `black .`
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ else:
 ## Node setup
 
 Follow the instructions in Algorand's [developer resources](https://developer.algorand.org/docs/run-a-node/setup/install/) to install a node on your computer.
+You can also set up a local [Algorand Sandbox](https://github.com/algorand/sandbox) with `make harness`.
 
 ## Running examples/example.py
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Install dependencies
 
 Run tests
 
-* `make docker-test`
+* `make harness`
 
 Set up the Algorand Sandbox based test-harness without running the tests
 
-* `make harness`
+* `make docker-test`
 
 Format code:
 

--- a/test-harness.sh
+++ b/test-harness.sh
@@ -55,7 +55,10 @@ echo "$THIS: seconds it took to get to end of cloning and copying: $(($(date "+%
 
 ## Start test harness environment
 pushd "$SDK_TESTING_HARNESS"
-./scripts/up.sh
+
+[[ "$VERBOSE_HARNESS" = 1 ]] && V_FLAG="-v" || V_FLAG=""
+echo "$THIS: standing up harnness with command [./up.sh $V_FLAG]"
+./scripts/up.sh "$V_FLAG"
 popd
 echo "$THIS: seconds it took to finish testing sdk's up.sh: $(($(date "+%s") - START))s"
 echo ""

--- a/test-harness.sh
+++ b/test-harness.sh
@@ -15,6 +15,8 @@ set +a
 rootdir=$(dirname "$0")
 pushd "$rootdir"
 
+echo "$THIS: VERBOSE_HARNESS=$VERBOSE_HARNESS"
+
 ## Reset test harness
 if [ -d "$SDK_TESTING_HARNESS" ]; then
   pushd "$SDK_TESTING_HARNESS"
@@ -28,11 +30,14 @@ fi
 git clone --depth 1 --single-branch --branch "$SDK_TESTING_BRANCH" "$SDK_TESTING_URL" "$SDK_TESTING_HARNESS"
 
 
+echo "$THIS: OVERWRITE_TESTING_ENVIRONMENT=$OVERWRITE_TESTING_ENVIRONMENT"
 if [[ $OVERWRITE_TESTING_ENVIRONMENT == 1 ]]; then
   echo "$THIS: OVERWRITE replaced $SDK_TESTING_HARNESS/.env with $ENV_FILE:"
   cp "$ENV_FILE" "$SDK_TESTING_HARNESS"/.env
 fi
 
+
+echo "$THIS: REMOVE_LOCAL_FEATURES=$REMOVE_LOCAL_FEATURES"
 ## Copy feature files into the project resources
 if [[ $REMOVE_LOCAL_FEATURES == 1 ]]; then
   echo "$THIS: OVERWRITE wipes clean $TEST_DIR/features"


### PR DESCRIPTION
# Summary

Following up from the companion [SDK Testing Bugfix PR](https://github.com/algorand/algorand-sdk-testing/pull/224), we're going to pass through verbosity to the harness script via a new `-v` flag.

For further context: here is what [SDK Testing Bugfix PR](https://github.com/algorand/algorand-sdk-testing/pull/224) says:
> The sandbox is always defaulting to `release` and the generated `config.harness` isn't sticking because the verbose flag is provided in the wrong order. 
> 
> Additionally, after refactoring the SDK Sandboxization PR's to no longer overwrite `.env`, there is no way to pass through the verbosity, except by overwriting. The PR re-enables passing through by also reading `VERBOSE_HARNESS` as a flag (either `-v` or `--verbose`).

## Testing
We can see that:
* previously the sandbox was defaulting to [release config](https://app.circleci.com/pipelines/github/algorand/py-algorand-sdk/864/workflows/80f949a4-acef-4e4e-88bd-f23d1c228709/jobs/3800?invite=true&invite=true#step-102-52)
* while now it is accepting [harness](https://app.circleci.com/pipelines/github/algorand/py-algorand-sdk/870/workflows/e32da492-eddc-4bfe-9e6c-91c6920f9bb4/jobs/3849?invite=true#step-102-59) and is [verbose](https://app.circleci.com/pipelines/github/algorand/py-algorand-sdk/870/workflows/e32da492-eddc-4bfe-9e6c-91c6920f9bb4/jobs/3849?invite=true#step-102-57)