### PR TITLE
Deprecation: Add deprecation warnings on v1 algod API and old transaction format

### DIFF
--- a/algosdk/algod.py
+++ b/algosdk/algod.py
@@ -1,14 +1,12 @@
-from urllib.request import Request, urlopen
-from urllib import parse
-import urllib.error
-import json
 import base64
+import json
+import urllib.error
+from urllib import parse
+from urllib.request import Request, urlopen
+
 import msgpack
-from . import error
-from . import encoding
-from . import constants
-from . import transaction
-from . import future
+
+from . import constants, encoding, error, future
 from .v2client.algod import _specify_round_string
 
 api_version_path_prefix = "/v1"

--- a/algosdk/algod.py
+++ b/algosdk/algod.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import urllib.error
+import warnings
 from urllib import parse
 from urllib.request import Request, urlopen
 
@@ -14,6 +15,10 @@ api_version_path_prefix = "/v1"
 
 class AlgodClient:
     """
+    NOTE: This class is deprecated:
+    v1 algod APIs are deprecated.
+    Please use the v2 equivalent in `v2client.algod` instead.
+
     Client class for kmd. Handles all algod requests.
 
     Args:
@@ -28,6 +33,11 @@ class AlgodClient:
     """
 
     def __init__(self, algod_token, algod_address, headers=None):
+        warnings.warn(
+            "`AlgodClient` is a part of v1 algod APIs that is deprecated. "
+            "Please use the v2 equivalent in `v2client.algod` instead.",
+            DeprecationWarning,
+        )
         self.algod_token = algod_token
         self.algod_address = algod_address
         self.headers = headers

--- a/algosdk/encoding.py
+++ b/algosdk/encoding.py
@@ -1,8 +1,11 @@
 import base64
-import msgpack
+import warnings
 from collections import OrderedDict
+
+import msgpack
 from Cryptodome.Hash import SHA512
-from . import transaction, error, auction, constants, future
+
+from . import auction, constants, error, future, transaction
 
 
 def msgpack_encode(obj):
@@ -94,6 +97,9 @@ def future_msgpack_decode(enc):
 
 def msgpack_decode(enc):
     """
+    NOTE: This method is deprecated:
+    Please use `future_msgpack_decode` instead.
+
     Decode a msgpack encoded object from a string.
 
     Args:
@@ -103,6 +109,11 @@ def msgpack_decode(enc):
         Transaction, SignedTransaction, Multisig, Bid, or SignedBid:\
             decoded object
     """
+    warnings.warn(
+        "`msgpack_decode` is being deprecated. "
+        "Please use `future_msgpack_decode` instead.",
+        DeprecationWarning,
+    )
     decoded = enc
     if not isinstance(enc, dict):
         decoded = msgpack.unpackb(base64.b64decode(enc), raw=False)

--- a/algosdk/future/transaction.py
+++ b/algosdk/future/transaction.py
@@ -1,18 +1,16 @@
-from typing import List, Union
 import base64
 import binascii
-from enum import IntEnum
-import msgpack
+import warnings
 from collections import OrderedDict
-from .. import account
-from .. import constants
-from .. import encoding
-from .. import error
-from .. import logic
-from .. import transaction
-from ..v2client import algod, models
-from nacl.signing import SigningKey, VerifyKey
+from enum import IntEnum
+from typing import List, Union
+
+import msgpack
 from nacl.exceptions import BadSignatureError
+from nacl.signing import SigningKey, VerifyKey
+
+from .. import account, constants, encoding, error, logic, transaction
+from ..v2client import algod, models
 
 
 class SuggestedParams:
@@ -273,6 +271,13 @@ class Transaction:
     def __eq__(self, other):
         if not isinstance(other, (Transaction, transaction.Transaction)):
             return False
+        if isinstance(other, transaction.Transaction):
+            warnings.warn(
+                "You are trying to check equality of an older `transaction` "
+                " format that is being deprecated. "
+                "Please use the v2 equivalent in `future.transaction` instead.",
+                DeprecationWarning,
+            )
         return (
             self.sender == other.sender
             and self.fee == other.fee

--- a/algosdk/kmd.py
+++ b/algosdk/kmd.py
@@ -1,12 +1,10 @@
-from urllib.request import Request, urlopen
-from urllib import parse
-import urllib.error
-import json
 import base64
-from . import encoding
-from . import error
-from . import transaction
-from . import constants
+import json
+import urllib.error
+from urllib import parse
+from urllib.request import Request, urlopen
+
+from . import constants, encoding, error, future
 
 api_version_path_prefix = "/v1"
 
@@ -383,7 +381,7 @@ class KMDClient:
         result = self.kmd_request("POST", req, data=query)
         pks = result["pks"]
         pks = [encoding.encode_address(base64.b64decode(p)) for p in pks]
-        msig = transaction.Multisig(
+        msig = future.transaction.Multisig(
             result["multisig_version"], result["threshold"], pks
         )
         return msig

--- a/algosdk/template.py
+++ b/algosdk/template.py
@@ -9,6 +9,7 @@ class Template:
     """
     NOTE: This class is deprecated
     """
+
     def get_address(self):
         """
         Return the address of the contract.
@@ -170,7 +171,7 @@ class Split(Template):
 class HTLC(Template):
     """
     NOTE: This class is deprecated
-    
+
     Hash Time Locked Contract allows a user to recieve the Algo prior to a
     deadline (in terms of a round) by proving knowledge of a special value
     or to forfeit the ability to claim, returning it to the payer.
@@ -553,7 +554,7 @@ class PeriodicPayment(Template):
 class LimitOrder(Template):
     """
     NOTE: This class is deprecated
-    
+
     Limit Order allows to trade Algos for other assets given a specific ratio;
     for N Algos, swap for Rate * N Assets.
 

--- a/algosdk/template.py
+++ b/algosdk/template.py
@@ -6,6 +6,9 @@ import base64
 
 
 class Template:
+    """
+    NOTE: This class is deprecated
+    """
     def get_address(self):
         """
         Return the address of the contract.
@@ -18,6 +21,8 @@ class Template:
 
 class Split(Template):
     """
+    NOTE: This class is deprecated
+
     Split allows locking algos in an account which allows transfering to two
     predefined addresses in a specified ratio such that for the given ratn and
     ratd parameters we have:
@@ -164,6 +169,8 @@ class Split(Template):
 
 class HTLC(Template):
     """
+    NOTE: This class is deprecated
+    
     Hash Time Locked Contract allows a user to recieve the Algo prior to a
     deadline (in terms of a round) by proving knowledge of a special value
     or to forfeit the ability to claim, returning it to the payer.
@@ -433,6 +440,8 @@ class DynamicFee(Template):
 
 class PeriodicPayment(Template):
     """
+    NOTE: This class is deprecated
+
     PeriodicPayment contract enables creating an account which allows the
     withdrawal of a fixed amount of assets every fixed number of rounds to a
     specific Algrorand Address. In addition, the contract allows to add
@@ -543,6 +552,8 @@ class PeriodicPayment(Template):
 
 class LimitOrder(Template):
     """
+    NOTE: This class is deprecated
+    
     Limit Order allows to trade Algos for other assets given a specific ratio;
     for N Algos, swap for Rate * N Assets.
 

--- a/algosdk/transaction.py
+++ b/algosdk/transaction.py
@@ -13,7 +13,7 @@ from . import account, constants, encoding, error, future, logic
 class Transaction:
     """
     NOTE: This class is deprecated:
-    Please use the v2 equivalent in `future.transaction` instead.
+    Please use the equivalent in `future.transaction` instead.
 
     Superclass for various transaction types.
     """
@@ -32,8 +32,8 @@ class Transaction:
         rekey_to,
     ):
         warnings.warn(
-            "`Transaction` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`Transaction` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         self.sender = sender
@@ -59,7 +59,7 @@ class Transaction:
     def get_txid(self):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
 
         Get the transaction's ID.
 
@@ -67,8 +67,8 @@ class Transaction:
             str: transaction ID
         """
         warnings.warn(
-            "`get_txid` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`get_txid` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         txn = encoding.msgpack_encode(self)
@@ -80,7 +80,7 @@ class Transaction:
     def sign(self, private_key):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
 
         Sign the transaction with a private key.
 
@@ -91,8 +91,8 @@ class Transaction:
             SignedTransaction: signed transaction with the signature
         """
         warnings.warn(
-            "`sign` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`sign` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         sig = self.raw_sign(private_key)
@@ -106,7 +106,7 @@ class Transaction:
     def raw_sign(self, private_key):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
 
         Sign the transaction.
 
@@ -117,8 +117,8 @@ class Transaction:
             bytes: signature
         """
         warnings.warn(
-            "`raw_sign` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`raw_sign` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         private_key = base64.b64decode(private_key)
@@ -132,11 +132,11 @@ class Transaction:
     def estimate_size(self):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`estimate_size` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`estimate_size` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         sk, _ = account.generate_account()
@@ -146,11 +146,11 @@ class Transaction:
     def dictify(self):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`dictify` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`dictify` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         d = dict()
@@ -179,11 +179,11 @@ class Transaction:
     def undictify(d):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`undictify` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`undictify` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         args = {
@@ -225,11 +225,11 @@ class Transaction:
     def __eq__(self, other):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`__eq__` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`__eq__` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         if not isinstance(
@@ -254,7 +254,7 @@ class Transaction:
 class PaymentTxn(Transaction):
     """
     NOTE: This class is deprecated:
-    Please use the v2 equivalent in `future.transaction` instead.
+    Please use the equivalent in `future.transaction` instead.
 
     Represents a payment transaction.
 
@@ -380,7 +380,7 @@ class PaymentTxn(Transaction):
 class KeyregTxn(Transaction):
     """
     NOTE: This class is deprecated:
-    Please use the v2 equivalent in `future.transaction` instead.
+    Please use the equivalent in `future.transaction` instead.
 
     Represents a key registration transaction.
 
@@ -505,7 +505,7 @@ class KeyregTxn(Transaction):
 class AssetConfigTxn(Transaction):
     """
     NOTE: This class is deprecated:
-    Please use the v2 equivalent in `future.transaction` instead.
+    Please use the equivalent in `future.transaction` instead.
 
     Represents a transaction for asset creation, reconfiguration, or
     destruction.
@@ -785,7 +785,7 @@ class AssetConfigTxn(Transaction):
 class AssetFreezeTxn(Transaction):
     """
     NOTE: This class is deprecated:
-    Please use the v2 equivalent in `future.transaction` instead.
+    Please use the equivalent in `future.transaction` instead.
 
     Represents a transaction for freezing or unfreezing an account's asset
     holdings. Must be issued by the asset's freeze manager.
@@ -904,7 +904,7 @@ class AssetFreezeTxn(Transaction):
 class AssetTransferTxn(Transaction):
     """
     NOTE: This class is deprecated:
-    Please use the v2 equivalent in `future.transaction` instead.
+    Please use the equivalent in `future.transaction` instead.
 
     Represents a transaction for asset transfer.
     To begin accepting an asset, supply the same address as both sender and
@@ -1059,7 +1059,7 @@ class AssetTransferTxn(Transaction):
 class SignedTransaction:
     """
     NOTE: This class is deprecated:
-    Please use the v2 equivalent in `future.transaction` instead.
+    Please use the equivalent in `future.transaction` instead.
 
     Represents a signed transaction.
 
@@ -1077,11 +1077,11 @@ class SignedTransaction:
     def __init__(self, transaction, signature, authorizing_address=None):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`SignedTransaction` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`SignedTransaction` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         self.signature = signature
@@ -1091,11 +1091,11 @@ class SignedTransaction:
     def dictify(self):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`dictify` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`dictify` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         od = OrderedDict()
@@ -1110,11 +1110,11 @@ class SignedTransaction:
     def undictify(d):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`undictify` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`undictify` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         sig = None
@@ -1130,11 +1130,11 @@ class SignedTransaction:
     def __eq__(self, other):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`__eq__` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`__eq__` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         if not isinstance(
@@ -1151,7 +1151,7 @@ class SignedTransaction:
 class MultisigTransaction:
     """
     NOTE: This class is deprecated:
-    Please use the v2 equivalent in `future.transaction` instead.
+    Please use the equivalent in `future.transaction` instead.
 
     Represents a signed transaction.
 
@@ -1167,11 +1167,11 @@ class MultisigTransaction:
     def __init__(self, transaction, multisig):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`MultisigTransaction` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`MultisigTransaction` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         self.transaction = transaction
@@ -1180,7 +1180,7 @@ class MultisigTransaction:
     def sign(self, private_key):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
 
         Sign the multisig transaction.
 
@@ -1195,8 +1195,8 @@ class MultisigTransaction:
             object with the same addresses.
         """
         warnings.warn(
-            "`sign` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`sign` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         self.multisig.validate()
@@ -1218,11 +1218,11 @@ class MultisigTransaction:
     def dictify(self):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`dictify` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`dictify` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         od = OrderedDict()
@@ -1235,11 +1235,11 @@ class MultisigTransaction:
     def undictify(d):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`undictify` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`undictify` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         msig = None
@@ -1253,7 +1253,7 @@ class MultisigTransaction:
     def merge(part_stxs):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
 
         Merge partially signed multisig transactions.
 
@@ -1270,8 +1270,8 @@ class MultisigTransaction:
             use MultisigTransaction.sign()
         """
         warnings.warn(
-            "`merge` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`merge` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         ref_addr = None
@@ -1301,11 +1301,11 @@ class MultisigTransaction:
     def __eq__(self, other):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`__eq__` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`__eq__` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         if not isinstance(
@@ -1322,7 +1322,7 @@ class MultisigTransaction:
 class Multisig:
     """
     NOTE: This class is deprecated:
-    Please use the v2 equivalent in `future.transaction` instead.
+    Please use the equivalent in `future.transaction` instead.
 
     Represents a multisig account and signatures.
 
@@ -1340,11 +1340,11 @@ class Multisig:
     def __init__(self, version, threshold, addresses):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`Multisig` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`Multisig` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         self.version = version
@@ -1356,13 +1356,13 @@ class Multisig:
     def validate(self):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
 
         Check if the multisig account is valid.
         """
         warnings.warn(
-            "`validate` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`validate` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         if not self.version == 1:
@@ -1379,13 +1379,13 @@ class Multisig:
     def address(self):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
 
         Return the multisig account address.
         """
         warnings.warn(
-            "`address` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`address` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         msig_bytes = (
@@ -1401,13 +1401,13 @@ class Multisig:
     def verify(self, message):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
 
         Verify that the multisig is valid for the message.
         """
         warnings.warn(
-            "`verify` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`verify` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         try:
@@ -1436,11 +1436,11 @@ class Multisig:
     def dictify(self):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`dictify` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`dictify` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         od = OrderedDict()
@@ -1452,11 +1452,11 @@ class Multisig:
     def json_dictify(self):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`json_dictify` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`json_dictify` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         d = {
@@ -1470,11 +1470,11 @@ class Multisig:
     def undictify(d):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`undictify` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`undictify` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         subsigs = [MultisigSubsig.undictify(s) for s in d["subsig"]]
@@ -1485,11 +1485,11 @@ class Multisig:
     def get_multisig_account(self):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`get_multisig_account` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`get_multisig_account` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         """Return a Multisig object without signatures."""
@@ -1501,11 +1501,11 @@ class Multisig:
     def get_public_keys(self):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`get_public_keys` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`get_public_keys` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         """Return the base32 encoded addresses for the multisig account."""
@@ -1515,11 +1515,11 @@ class Multisig:
     def __eq__(self, other):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`__eq__` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`__eq__` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         if not isinstance(other, (Multisig, future.transaction.Multisig)):
@@ -1534,7 +1534,7 @@ class Multisig:
 class MultisigSubsig:
     """
     NOTE: This class is deprecated:
-    Please use the v2 equivalent in `future.transaction` instead.
+    Please use the equivalent in `future.transaction` instead.
 
     Attributes:
         public_key (bytes)
@@ -1544,11 +1544,11 @@ class MultisigSubsig:
     def __init__(self, public_key, signature=None):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`MultisigSubsig` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`MultisigSubsig` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         self.public_key = public_key
@@ -1557,11 +1557,11 @@ class MultisigSubsig:
     def dictify(self):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`dictify` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`dictify` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         od = OrderedDict()
@@ -1573,11 +1573,11 @@ class MultisigSubsig:
     def json_dictify(self):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`json_dictify` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`json_dictify` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         d = {"pk": base64.b64encode(self.public_key).decode()}
@@ -1589,11 +1589,11 @@ class MultisigSubsig:
     def undictify(d):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`undictify` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`undictify` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         sig = None
@@ -1605,11 +1605,11 @@ class MultisigSubsig:
     def __eq__(self, other):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`__eq__` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`__eq__` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         if not isinstance(
@@ -1625,7 +1625,7 @@ class MultisigSubsig:
 class LogicSig:
     """
     NOTE: This class is deprecated:
-    Please use the v2 equivalent in `future.transaction` instead.
+    Please use the equivalent in `future.transaction` instead.
 
     Represents a logic signature.
 
@@ -1643,11 +1643,11 @@ class LogicSig:
     def __init__(self, program, args=None):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`LogicSig` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`LogicSig` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         self._sanity_check_program(program)
@@ -1660,7 +1660,7 @@ class LogicSig:
     def _sanity_check_program(program):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
 
         Performs heuristic program validation:
         check if passed in bytes are Algorand address, or they are B64 encoded, rather than Teal bytes
@@ -1678,8 +1678,8 @@ class LogicSig:
             )
 
         warnings.warn(
-            "`_sanity_check_program` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`_sanity_check_program` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         if not program:
@@ -1709,11 +1709,11 @@ class LogicSig:
     def dictify(self):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`dictify` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`dictify` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         od = OrderedDict()
@@ -1730,11 +1730,11 @@ class LogicSig:
     def undictify(d):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`undictify` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`undictify` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         lsig = LogicSig(d["l"], d.get("arg", None))
@@ -1747,7 +1747,7 @@ class LogicSig:
     def verify(self, public_key):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
 
         Verifies LogicSig against the transaction's sender address
 
@@ -1760,8 +1760,8 @@ class LogicSig:
                 address), false otherwise
         """
         warnings.warn(
-            "`verify` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`verify` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         if self.sig and self.msig:
@@ -1791,7 +1791,7 @@ class LogicSig:
     def address(self):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
 
         Compute hash of the logic sig program (that is the same as escrow
         account address) as string address
@@ -1800,8 +1800,8 @@ class LogicSig:
             str: program address
         """
         warnings.warn(
-            "`address` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`address` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         return logic.address(self.logic)
@@ -1810,11 +1810,11 @@ class LogicSig:
     def sign_program(program, private_key):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`sign_program` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`sign_program` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         private_key = base64.b64decode(private_key)
@@ -1827,11 +1827,11 @@ class LogicSig:
     def single_sig_multisig(program, private_key, multisig):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`single_sig_multisig` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`single_sig_multisig` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         index = -1
@@ -1850,7 +1850,7 @@ class LogicSig:
     def sign(self, private_key, multisig=None):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
 
         Creates signature (if no pk provided) or multi signature
 
@@ -1864,8 +1864,8 @@ class LogicSig:
                 object
         """
         warnings.warn(
-            "`sign` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`sign` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         if not multisig:
@@ -1880,7 +1880,7 @@ class LogicSig:
     def append_to_multisig(self, private_key):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
 
         Appends a signature to multi signature
 
@@ -1892,8 +1892,8 @@ class LogicSig:
                 object
         """
         warnings.warn(
-            "`append_to_multisig` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`append_to_multisig` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         if self.msig is None:
@@ -1906,11 +1906,11 @@ class LogicSig:
     def __eq__(self, other):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`__eq__` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`__eq__` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         if not isinstance(other, (LogicSig, future.transaction.LogicSig)):
@@ -1926,7 +1926,7 @@ class LogicSig:
 class LogicSigTransaction:
     """
     NOTE: This class is deprecated:
-    Please use the v2 equivalent in `future.transaction` instead.
+    Please use the equivalent in `future.transaction` instead.
 
     Represents a logic signed transaction.
 
@@ -1942,11 +1942,11 @@ class LogicSigTransaction:
     def __init__(self, transaction, lsig):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`LogicSigTransaction` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`LogicSigTransaction` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         self.transaction = transaction
@@ -1955,7 +1955,7 @@ class LogicSigTransaction:
     def verify(self):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
 
         Verify LogicSig against the transaction
 
@@ -1965,8 +1965,8 @@ class LogicSigTransaction:
                 address), false otherwise
         """
         warnings.warn(
-            "`verify` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`verify` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         public_key = encoding.decode_address(self.transaction.sender)
@@ -1975,11 +1975,11 @@ class LogicSigTransaction:
     def dictify(self):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`dictify` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`dictify` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         od = OrderedDict()
@@ -1992,11 +1992,11 @@ class LogicSigTransaction:
     def undictify(d):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`undictify` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`undictify` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         lsig = None
@@ -2009,11 +2009,11 @@ class LogicSigTransaction:
     def __eq__(self, other):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`__eq__` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`__eq__` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         if not isinstance(
@@ -2029,7 +2029,7 @@ class LogicSigTransaction:
 def write_to_file(objs, path, overwrite=True):
     """
     NOTE: This method is deprecated:
-    Please use the v2 equivalent in `future.transaction` instead.
+    Please use the equivalent in `future.transaction` instead.
 
     Write signed or unsigned transactions to a file.
 
@@ -2055,8 +2055,8 @@ def write_to_file(objs, path, overwrite=True):
         bool: true if the transactions have been written to the file
     """
     warnings.warn(
-        "`write_to_file` is a part of v1 `transaction` that is being deprecated. "
-        "Please use the v2 equivalent in `future.transaction` instead.",
+        "`write_to_file` is a part of an older `transaction` format that is being deprecated. "
+        "Please use the equivalent in `future.transaction` instead.",
         DeprecationWarning,
     )
     f = None
@@ -2082,7 +2082,7 @@ def write_to_file(objs, path, overwrite=True):
 def retrieve_from_file(path):
     """
     NOTE: This method is deprecated:
-    Please use the v2 equivalent in `future.transaction` instead.
+    Please use the equivalent in `future.transaction` instead.
 
     Retrieve encoded objects from a file.
 
@@ -2093,8 +2093,8 @@ def retrieve_from_file(path):
         Object[]: list of objects
     """
     warnings.warn(
-        "`retrieve_from_file` is a part of v1 `transaction` that is being deprecated. "
-        "Please use the v2 equivalent in `future.transaction` instead.",
+        "`retrieve_from_file` is a part of an older `transaction` format that is being deprecated. "
+        "Please use the equivalent in `future.transaction` instead.",
         DeprecationWarning,
     )
     f = open(path, "rb")
@@ -2109,17 +2109,17 @@ def retrieve_from_file(path):
 class TxGroup:
     """
     NOTE: This class is deprecated:
-    Please use the v2 equivalent in `future.transaction` instead.
+    Please use the equivalent in `future.transaction` instead.
     """
 
     def __init__(self, txns):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`TxGroup` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`TxGroup` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         assert isinstance(txns, list)
@@ -2136,11 +2136,11 @@ class TxGroup:
     def dictify(self):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`dictify` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`dictify` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         od = OrderedDict()
@@ -2151,11 +2151,11 @@ class TxGroup:
     def undictify(d):
         """
         NOTE: This method is deprecated:
-        Please use the v2 equivalent in `future.transaction` instead.
+        Please use the equivalent in `future.transaction` instead.
         """
         warnings.warn(
-            "`undictify` is a part of v1 `transaction` that is being deprecated. "
-            "Please use the v2 equivalent in `future.transaction` instead.",
+            "`undictify` is a part of an older `transaction` format that is being deprecated. "
+            "Please use the equivalent in `future.transaction` instead.",
             DeprecationWarning,
         )
         txg = TxGroup(d["txlist"])
@@ -2165,7 +2165,7 @@ class TxGroup:
 def calculate_group_id(txns):
     """
     NOTE: This method is deprecated:
-    Please use the v2 equivalent in `future.transaction` instead.
+    Please use the equivalent in `future.transaction` instead.
 
     Calculate group id for a given list of unsigned transactions
 
@@ -2176,8 +2176,8 @@ def calculate_group_id(txns):
         bytes: checksum value representing the group id
     """
     warnings.warn(
-        "`calculate_group_id` is a part of v1 `transaction` that is being deprecated. "
-        "Please use the v2 equivalent in `future.transaction` instead.",
+        "`calculate_group_id` is a part of an older `transaction` format that is being deprecated. "
+        "Please use the equivalent in `future.transaction` instead.",
         DeprecationWarning,
     )
     if len(txns) > constants.tx_group_limit:
@@ -2199,7 +2199,7 @@ def calculate_group_id(txns):
 def assign_group_id(txns, address=None):
     """
     NOTE: This method is deprecated:
-    Please use the v2 equivalent in `future.transaction` instead.
+    Please use the equivalent in `future.transaction` instead.
 
     Assign group id to a given list of unsigned transactions.
 
@@ -2212,8 +2212,8 @@ def assign_group_id(txns, address=None):
         txns (list): list of unsigned transactions with group property set
     """
     warnings.warn(
-        "`assign_group_id` is a part of v1 `transaction` that is being deprecated. "
-        "Please use the v2 equivalent in `future.transaction` instead.",
+        "`assign_group_id` is a part of an older `transaction` format that is being deprecated. "
+        "Please use the equivalent in `future.transaction` instead.",
         DeprecationWarning,
     )
     if len(txns) > constants.tx_group_limit:

--- a/algosdk/transaction.py
+++ b/algosdk/transaction.py
@@ -66,11 +66,6 @@ class Transaction:
         Returns:
             str: transaction ID
         """
-        warnings.warn(
-            "`get_txid` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         txn = encoding.msgpack_encode(self)
         to_sign = constants.txid_prefix + base64.b64decode(txn)
         txid = encoding.checksum(to_sign)
@@ -90,11 +85,6 @@ class Transaction:
         Returns:
             SignedTransaction: signed transaction with the signature
         """
-        warnings.warn(
-            "`sign` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         sig = self.raw_sign(private_key)
         sig = base64.b64encode(sig).decode()
         authorizing_address = None
@@ -116,11 +106,6 @@ class Transaction:
         Returns:
             bytes: signature
         """
-        warnings.warn(
-            "`raw_sign` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         private_key = base64.b64decode(private_key)
         txn = encoding.msgpack_encode(self)
         to_sign = constants.txid_prefix + base64.b64decode(txn)
@@ -134,11 +119,6 @@ class Transaction:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`estimate_size` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         sk, _ = account.generate_account()
         stx = self.sign(sk)
         return len(base64.b64decode(encoding.msgpack_encode(stx)))
@@ -148,11 +128,6 @@ class Transaction:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`dictify` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         d = dict()
         if self.fee:
             d["fee"] = self.fee
@@ -181,11 +156,6 @@ class Transaction:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`undictify` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         args = {
             "sender": encoding.encode_address(d["snd"]),
             "fee": d["fee"] if "fee" in d else 0,
@@ -227,11 +197,6 @@ class Transaction:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`__eq__` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         if not isinstance(
             other, (Transaction, future.transaction.Transaction)
         ):
@@ -1093,11 +1058,6 @@ class SignedTransaction:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`dictify` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         od = OrderedDict()
         if self.signature:
             od["sig"] = base64.b64decode(self.signature)
@@ -1112,11 +1072,6 @@ class SignedTransaction:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`undictify` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         sig = None
         if "sig" in d:
             sig = base64.b64encode(d["sig"]).decode()
@@ -1132,11 +1087,6 @@ class SignedTransaction:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`__eq__` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         if not isinstance(
             other, (SignedTransaction, future.transaction.SignedTransaction)
         ):
@@ -1194,11 +1144,6 @@ class MultisigTransaction:
             can use Multisig.get_multisig_account() to get a new multisig
             object with the same addresses.
         """
-        warnings.warn(
-            "`sign` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         self.multisig.validate()
         addr = self.multisig.address()
         if not self.transaction.sender == addr:
@@ -1220,11 +1165,6 @@ class MultisigTransaction:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`dictify` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         od = OrderedDict()
         if self.multisig:
             od["msig"] = self.multisig.dictify()
@@ -1237,11 +1177,6 @@ class MultisigTransaction:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`undictify` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         msig = None
         if "msig" in d:
             msig = Multisig.undictify(d["msig"])
@@ -1269,11 +1204,6 @@ class MultisigTransaction:
             transactions. To append a signature to a multisig transaction, just
             use MultisigTransaction.sign()
         """
-        warnings.warn(
-            "`merge` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         ref_addr = None
         for stx in part_stxs:
             if not ref_addr:
@@ -1303,11 +1233,6 @@ class MultisigTransaction:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`__eq__` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         if not isinstance(
             other,
             (MultisigTransaction, future.transaction.MultisigTransaction),
@@ -1360,11 +1285,6 @@ class Multisig:
 
         Check if the multisig account is valid.
         """
-        warnings.warn(
-            "`validate` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         if not self.version == 1:
             raise error.UnknownMsigVersionError
         if (
@@ -1383,11 +1303,6 @@ class Multisig:
 
         Return the multisig account address.
         """
-        warnings.warn(
-            "`address` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         msig_bytes = (
             bytes(constants.msig_addr_prefix, "utf-8")
             + bytes([self.version])
@@ -1405,11 +1320,6 @@ class Multisig:
 
         Verify that the multisig is valid for the message.
         """
-        warnings.warn(
-            "`verify` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         try:
             self.validate()
         except (error.UnknownMsigVersionError, error.InvalidThresholdError):
@@ -1438,11 +1348,6 @@ class Multisig:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`dictify` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         od = OrderedDict()
         od["subsig"] = [subsig.dictify() for subsig in self.subsigs]
         od["thr"] = self.threshold
@@ -1454,11 +1359,6 @@ class Multisig:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`json_dictify` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         d = {
             "subsig": [subsig.json_dictify() for subsig in self.subsigs],
             "thr": self.threshold,
@@ -1472,11 +1372,6 @@ class Multisig:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`undictify` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         subsigs = [MultisigSubsig.undictify(s) for s in d["subsig"]]
         msig = Multisig(d["v"], d["thr"], [])
         msig.subsigs = subsigs
@@ -1487,11 +1382,6 @@ class Multisig:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`get_multisig_account` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         """Return a Multisig object without signatures."""
         msig = Multisig(self.version, self.threshold, self.get_public_keys())
         for s in msig.subsigs:
@@ -1503,11 +1393,6 @@ class Multisig:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`get_public_keys` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         """Return the base32 encoded addresses for the multisig account."""
         pks = [encoding.encode_address(s.public_key) for s in self.subsigs]
         return pks
@@ -1517,11 +1402,6 @@ class Multisig:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`__eq__` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         if not isinstance(other, (Multisig, future.transaction.Multisig)):
             return False
         return (
@@ -1559,11 +1439,6 @@ class MultisigSubsig:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`dictify` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         od = OrderedDict()
         od["pk"] = self.public_key
         if self.signature:
@@ -1575,11 +1450,6 @@ class MultisigSubsig:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`json_dictify` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         d = {"pk": base64.b64encode(self.public_key).decode()}
         if self.signature:
             d["s"] = base64.b64encode(self.signature).decode()
@@ -1591,11 +1461,6 @@ class MultisigSubsig:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`undictify` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         sig = None
         if "s" in d:
             sig = d["s"]
@@ -1607,11 +1472,6 @@ class MultisigSubsig:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`__eq__` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         if not isinstance(
             other, (MultisigSubsig, future.transaction.MultisigSubsig)
         ):
@@ -1677,11 +1537,6 @@ class LogicSig:
                 )
             )
 
-        warnings.warn(
-            "`_sanity_check_program` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         if not program:
             raise error.InvalidProgram("empty program")
 
@@ -1711,11 +1566,6 @@ class LogicSig:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`dictify` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         od = OrderedDict()
         if self.args:
             od["arg"] = self.args
@@ -1732,11 +1582,6 @@ class LogicSig:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`undictify` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         lsig = LogicSig(d["l"], d.get("arg", None))
         if "sig" in d:
             lsig.sig = base64.b64encode(d["sig"]).decode()
@@ -1759,11 +1604,6 @@ class LogicSig:
                 the logic hash or the signature is valid against the sender\
                 address), false otherwise
         """
-        warnings.warn(
-            "`verify` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         if self.sig and self.msig:
             return False
 
@@ -1799,11 +1639,6 @@ class LogicSig:
         Returns:
             str: program address
         """
-        warnings.warn(
-            "`address` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         return logic.address(self.logic)
 
     @staticmethod
@@ -1812,11 +1647,6 @@ class LogicSig:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`sign_program` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         private_key = base64.b64decode(private_key)
         signing_key = SigningKey(private_key[: constants.key_len_bytes])
         to_sign = constants.logic_prefix + program
@@ -1829,11 +1659,6 @@ class LogicSig:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`single_sig_multisig` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         index = -1
         public_key = base64.b64decode(bytes(private_key, "utf-8"))
         public_key = public_key[constants.key_len_bytes :]
@@ -1863,11 +1688,6 @@ class LogicSig:
             InvalidSecretKeyError: if no matching private key in multisig\
                 object
         """
-        warnings.warn(
-            "`sign` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         if not multisig:
             self.sig = LogicSig.sign_program(self.logic, private_key)
         else:
@@ -1891,11 +1711,6 @@ class LogicSig:
             InvalidSecretKeyError: if no matching private key in multisig\
                 object
         """
-        warnings.warn(
-            "`append_to_multisig` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         if self.msig is None:
             raise error.InvalidSecretKeyError
         sig, index = LogicSig.single_sig_multisig(
@@ -1908,11 +1723,6 @@ class LogicSig:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`__eq__` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         if not isinstance(other, (LogicSig, future.transaction.LogicSig)):
             return False
         return (
@@ -1964,11 +1774,6 @@ class LogicSigTransaction:
                 the logic hash or the signature is valid against the sender\
                 address), false otherwise
         """
-        warnings.warn(
-            "`verify` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         public_key = encoding.decode_address(self.transaction.sender)
         return self.lsig.verify(public_key)
 
@@ -1977,11 +1782,6 @@ class LogicSigTransaction:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`dictify` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         od = OrderedDict()
         if self.lsig:
             od["lsig"] = self.lsig.dictify()
@@ -1994,11 +1794,6 @@ class LogicSigTransaction:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`undictify` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         lsig = None
         if "lsig" in d:
             lsig = LogicSig.undictify(d["lsig"])
@@ -2011,11 +1806,6 @@ class LogicSigTransaction:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`__eq__` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         if not isinstance(
             other,
             (LogicSigTransaction, future.transaction.LogicSigTransaction),
@@ -2138,11 +1928,6 @@ class TxGroup:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`dictify` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         od = OrderedDict()
         od["txlist"] = self.transactions
         return od
@@ -2153,11 +1938,6 @@ class TxGroup:
         NOTE: This method is deprecated:
         Please use the equivalent in `future.transaction` instead.
         """
-        warnings.warn(
-            "`undictify` is a part of an older `transaction` format that is being deprecated. "
-            "Please use the equivalent in `future.transaction` instead.",
-            DeprecationWarning,
-        )
         txg = TxGroup(d["txlist"])
         return txg
 

--- a/algosdk/transaction.py
+++ b/algosdk/transaction.py
@@ -1,19 +1,20 @@
 import base64
-import msgpack
 import binascii
+import warnings
 from collections import OrderedDict
-from . import account
-from . import constants
-from . import encoding
-from . import error
-from . import logic
-from . import future
-from nacl.signing import SigningKey, VerifyKey
+
+import msgpack
 from nacl.exceptions import BadSignatureError
+from nacl.signing import SigningKey, VerifyKey
+
+from . import account, constants, encoding, error, future, logic
 
 
 class Transaction:
     """
+    NOTE: This class is deprecated:
+    Please use the v2 equivalent in `future.transaction` instead.
+
     Superclass for various transaction types.
     """
 
@@ -30,6 +31,11 @@ class Transaction:
         txn_type,
         rekey_to,
     ):
+        warnings.warn(
+            "`Transaction` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         self.sender = sender
         self.fee = fee
         self.first_valid_round = first
@@ -52,11 +58,19 @@ class Transaction:
 
     def get_txid(self):
         """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+
         Get the transaction's ID.
 
         Returns:
             str: transaction ID
         """
+        warnings.warn(
+            "`get_txid` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         txn = encoding.msgpack_encode(self)
         to_sign = constants.txid_prefix + base64.b64decode(txn)
         txid = encoding.checksum(to_sign)
@@ -65,6 +79,9 @@ class Transaction:
 
     def sign(self, private_key):
         """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+
         Sign the transaction with a private key.
 
         Args:
@@ -73,6 +90,11 @@ class Transaction:
         Returns:
             SignedTransaction: signed transaction with the signature
         """
+        warnings.warn(
+            "`sign` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         sig = self.raw_sign(private_key)
         sig = base64.b64encode(sig).decode()
         authorizing_address = None
@@ -83,6 +105,9 @@ class Transaction:
 
     def raw_sign(self, private_key):
         """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+
         Sign the transaction.
 
         Args:
@@ -91,6 +116,11 @@ class Transaction:
         Returns:
             bytes: signature
         """
+        warnings.warn(
+            "`raw_sign` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         private_key = base64.b64decode(private_key)
         txn = encoding.msgpack_encode(self)
         to_sign = constants.txid_prefix + base64.b64decode(txn)
@@ -100,11 +130,29 @@ class Transaction:
         return sig
 
     def estimate_size(self):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`estimate_size` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         sk, _ = account.generate_account()
         stx = self.sign(sk)
         return len(base64.b64decode(encoding.msgpack_encode(stx)))
 
     def dictify(self):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`dictify` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         d = dict()
         if self.fee:
             d["fee"] = self.fee
@@ -129,6 +177,15 @@ class Transaction:
 
     @staticmethod
     def undictify(d):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`undictify` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         args = {
             "sender": encoding.encode_address(d["snd"]),
             "fee": d["fee"] if "fee" in d else 0,
@@ -166,6 +223,15 @@ class Transaction:
         return txn
 
     def __eq__(self, other):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`__eq__` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         if not isinstance(
             other, (Transaction, future.transaction.Transaction)
         ):
@@ -187,6 +253,9 @@ class Transaction:
 
 class PaymentTxn(Transaction):
     """
+    NOTE: This class is deprecated:
+    Please use the v2 equivalent in `future.transaction` instead.
+
     Represents a payment transaction.
 
     Args:
@@ -310,6 +379,9 @@ class PaymentTxn(Transaction):
 
 class KeyregTxn(Transaction):
     """
+    NOTE: This class is deprecated:
+    Please use the v2 equivalent in `future.transaction` instead.
+
     Represents a key registration transaction.
 
     Args:
@@ -432,6 +504,9 @@ class KeyregTxn(Transaction):
 
 class AssetConfigTxn(Transaction):
     """
+    NOTE: This class is deprecated:
+    Please use the v2 equivalent in `future.transaction` instead.
+
     Represents a transaction for asset creation, reconfiguration, or
     destruction.
 
@@ -709,6 +784,9 @@ class AssetConfigTxn(Transaction):
 
 class AssetFreezeTxn(Transaction):
     """
+    NOTE: This class is deprecated:
+    Please use the v2 equivalent in `future.transaction` instead.
+
     Represents a transaction for freezing or unfreezing an account's asset
     holdings. Must be issued by the asset's freeze manager.
 
@@ -825,6 +903,9 @@ class AssetFreezeTxn(Transaction):
 
 class AssetTransferTxn(Transaction):
     """
+    NOTE: This class is deprecated:
+    Please use the v2 equivalent in `future.transaction` instead.
+
     Represents a transaction for asset transfer.
     To begin accepting an asset, supply the same address as both sender and
     receiver, and set amount to 0.
@@ -977,6 +1058,9 @@ class AssetTransferTxn(Transaction):
 
 class SignedTransaction:
     """
+    NOTE: This class is deprecated:
+    Please use the v2 equivalent in `future.transaction` instead.
+
     Represents a signed transaction.
 
     Args:
@@ -991,11 +1075,29 @@ class SignedTransaction:
     """
 
     def __init__(self, transaction, signature, authorizing_address=None):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`SignedTransaction` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         self.signature = signature
         self.transaction = transaction
         self.authorizing_address = authorizing_address
 
     def dictify(self):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`dictify` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         od = OrderedDict()
         if self.signature:
             od["sig"] = base64.b64decode(self.signature)
@@ -1006,6 +1108,15 @@ class SignedTransaction:
 
     @staticmethod
     def undictify(d):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`undictify` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         sig = None
         if "sig" in d:
             sig = base64.b64encode(d["sig"]).decode()
@@ -1017,6 +1128,15 @@ class SignedTransaction:
         return stx
 
     def __eq__(self, other):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`__eq__` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         if not isinstance(
             other, (SignedTransaction, future.transaction.SignedTransaction)
         ):
@@ -1030,6 +1150,9 @@ class SignedTransaction:
 
 class MultisigTransaction:
     """
+    NOTE: This class is deprecated:
+    Please use the v2 equivalent in `future.transaction` instead.
+
     Represents a signed transaction.
 
     Args:
@@ -1042,11 +1165,23 @@ class MultisigTransaction:
     """
 
     def __init__(self, transaction, multisig):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`MultisigTransaction` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         self.transaction = transaction
         self.multisig = multisig
 
     def sign(self, private_key):
         """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+
         Sign the multisig transaction.
 
         Args:
@@ -1059,6 +1194,11 @@ class MultisigTransaction:
             can use Multisig.get_multisig_account() to get a new multisig
             object with the same addresses.
         """
+        warnings.warn(
+            "`sign` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         self.multisig.validate()
         addr = self.multisig.address()
         if not self.transaction.sender == addr:
@@ -1076,6 +1216,15 @@ class MultisigTransaction:
         self.multisig.subsigs[index].signature = sig
 
     def dictify(self):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`dictify` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         od = OrderedDict()
         if self.multisig:
             od["msig"] = self.multisig.dictify()
@@ -1084,6 +1233,15 @@ class MultisigTransaction:
 
     @staticmethod
     def undictify(d):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`undictify` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         msig = None
         if "msig" in d:
             msig = Multisig.undictify(d["msig"])
@@ -1094,6 +1252,9 @@ class MultisigTransaction:
     @staticmethod
     def merge(part_stxs):
         """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+
         Merge partially signed multisig transactions.
 
         Args:
@@ -1108,6 +1269,11 @@ class MultisigTransaction:
             transactions. To append a signature to a multisig transaction, just
             use MultisigTransaction.sign()
         """
+        warnings.warn(
+            "`merge` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         ref_addr = None
         for stx in part_stxs:
             if not ref_addr:
@@ -1133,6 +1299,15 @@ class MultisigTransaction:
         return msigstx
 
     def __eq__(self, other):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`__eq__` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         if not isinstance(
             other,
             (MultisigTransaction, future.transaction.MultisigTransaction),
@@ -1146,6 +1321,9 @@ class MultisigTransaction:
 
 class Multisig:
     """
+    NOTE: This class is deprecated:
+    Please use the v2 equivalent in `future.transaction` instead.
+
     Represents a multisig account and signatures.
 
     Args:
@@ -1160,6 +1338,15 @@ class Multisig:
     """
 
     def __init__(self, version, threshold, addresses):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`Multisig` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         self.version = version
         self.threshold = threshold
         self.subsigs = []
@@ -1167,7 +1354,17 @@ class Multisig:
             self.subsigs.append(MultisigSubsig(encoding.decode_address(a)))
 
     def validate(self):
-        """Check if the multisig account is valid."""
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+
+        Check if the multisig account is valid.
+        """
+        warnings.warn(
+            "`validate` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         if not self.version == 1:
             raise error.UnknownMsigVersionError
         if (
@@ -1180,7 +1377,17 @@ class Multisig:
             raise error.MultisigAccountSizeError
 
     def address(self):
-        """Return the multisig account address."""
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+
+        Return the multisig account address.
+        """
+        warnings.warn(
+            "`address` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         msig_bytes = (
             bytes(constants.msig_addr_prefix, "utf-8")
             + bytes([self.version])
@@ -1192,7 +1399,17 @@ class Multisig:
         return encoding.encode_address(addr)
 
     def verify(self, message):
-        """Verify that the multisig is valid for the message."""
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+
+        Verify that the multisig is valid for the message.
+        """
+        warnings.warn(
+            "`verify` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         try:
             self.validate()
         except (error.UnknownMsigVersionError, error.InvalidThresholdError):
@@ -1217,6 +1434,15 @@ class Multisig:
         return True
 
     def dictify(self):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`dictify` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         od = OrderedDict()
         od["subsig"] = [subsig.dictify() for subsig in self.subsigs]
         od["thr"] = self.threshold
@@ -1224,6 +1450,15 @@ class Multisig:
         return od
 
     def json_dictify(self):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`json_dictify` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         d = {
             "subsig": [subsig.json_dictify() for subsig in self.subsigs],
             "thr": self.threshold,
@@ -1233,12 +1468,30 @@ class Multisig:
 
     @staticmethod
     def undictify(d):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`undictify` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         subsigs = [MultisigSubsig.undictify(s) for s in d["subsig"]]
         msig = Multisig(d["v"], d["thr"], [])
         msig.subsigs = subsigs
         return msig
 
     def get_multisig_account(self):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`get_multisig_account` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         """Return a Multisig object without signatures."""
         msig = Multisig(self.version, self.threshold, self.get_public_keys())
         for s in msig.subsigs:
@@ -1246,11 +1499,29 @@ class Multisig:
         return msig
 
     def get_public_keys(self):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`get_public_keys` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         """Return the base32 encoded addresses for the multisig account."""
         pks = [encoding.encode_address(s.public_key) for s in self.subsigs]
         return pks
 
     def __eq__(self, other):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`__eq__` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         if not isinstance(other, (Multisig, future.transaction.Multisig)):
             return False
         return (
@@ -1262,16 +1533,37 @@ class Multisig:
 
 class MultisigSubsig:
     """
+    NOTE: This class is deprecated:
+    Please use the v2 equivalent in `future.transaction` instead.
+
     Attributes:
         public_key (bytes)
         signature (bytes)
     """
 
     def __init__(self, public_key, signature=None):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`MultisigSubsig` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         self.public_key = public_key
         self.signature = signature
 
     def dictify(self):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`dictify` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         od = OrderedDict()
         od["pk"] = self.public_key
         if self.signature:
@@ -1279,6 +1571,15 @@ class MultisigSubsig:
         return od
 
     def json_dictify(self):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`json_dictify` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         d = {"pk": base64.b64encode(self.public_key).decode()}
         if self.signature:
             d["s"] = base64.b64encode(self.signature).decode()
@@ -1286,6 +1587,15 @@ class MultisigSubsig:
 
     @staticmethod
     def undictify(d):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`undictify` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         sig = None
         if "s" in d:
             sig = d["s"]
@@ -1293,6 +1603,15 @@ class MultisigSubsig:
         return mss
 
     def __eq__(self, other):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`__eq__` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         if not isinstance(
             other, (MultisigSubsig, future.transaction.MultisigSubsig)
         ):
@@ -1305,6 +1624,9 @@ class MultisigSubsig:
 
 class LogicSig:
     """
+    NOTE: This class is deprecated:
+    Please use the v2 equivalent in `future.transaction` instead.
+
     Represents a logic signature.
 
     Arguments:
@@ -1319,6 +1641,15 @@ class LogicSig:
     """
 
     def __init__(self, program, args=None):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`LogicSig` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         self._sanity_check_program(program)
         self.logic = program
         self.args = args
@@ -1328,6 +1659,9 @@ class LogicSig:
     @staticmethod
     def _sanity_check_program(program):
         """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+
         Performs heuristic program validation:
         check if passed in bytes are Algorand address, or they are B64 encoded, rather than Teal bytes
 
@@ -1343,6 +1677,11 @@ class LogicSig:
                 )
             )
 
+        warnings.warn(
+            "`_sanity_check_program` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         if not program:
             raise error.InvalidProgram("empty program")
 
@@ -1368,6 +1707,15 @@ class LogicSig:
             )
 
     def dictify(self):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`dictify` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         od = OrderedDict()
         if self.args:
             od["arg"] = self.args
@@ -1380,6 +1728,15 @@ class LogicSig:
 
     @staticmethod
     def undictify(d):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`undictify` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         lsig = LogicSig(d["l"], d.get("arg", None))
         if "sig" in d:
             lsig.sig = base64.b64encode(d["sig"]).decode()
@@ -1389,6 +1746,9 @@ class LogicSig:
 
     def verify(self, public_key):
         """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+
         Verifies LogicSig against the transaction's sender address
 
         Args:
@@ -1399,6 +1759,11 @@ class LogicSig:
                 the logic hash or the signature is valid against the sender\
                 address), false otherwise
         """
+        warnings.warn(
+            "`verify` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         if self.sig and self.msig:
             return False
 
@@ -1425,16 +1790,33 @@ class LogicSig:
 
     def address(self):
         """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+
         Compute hash of the logic sig program (that is the same as escrow
         account address) as string address
 
         Returns:
             str: program address
         """
+        warnings.warn(
+            "`address` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         return logic.address(self.logic)
 
     @staticmethod
     def sign_program(program, private_key):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`sign_program` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         private_key = base64.b64decode(private_key)
         signing_key = SigningKey(private_key[: constants.key_len_bytes])
         to_sign = constants.logic_prefix + program
@@ -1443,6 +1825,15 @@ class LogicSig:
 
     @staticmethod
     def single_sig_multisig(program, private_key, multisig):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`single_sig_multisig` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         index = -1
         public_key = base64.b64decode(bytes(private_key, "utf-8"))
         public_key = public_key[constants.key_len_bytes :]
@@ -1458,6 +1849,9 @@ class LogicSig:
 
     def sign(self, private_key, multisig=None):
         """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+
         Creates signature (if no pk provided) or multi signature
 
         Args:
@@ -1469,7 +1863,11 @@ class LogicSig:
             InvalidSecretKeyError: if no matching private key in multisig\
                 object
         """
-
+        warnings.warn(
+            "`sign` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         if not multisig:
             self.sig = LogicSig.sign_program(self.logic, private_key)
         else:
@@ -1481,6 +1879,9 @@ class LogicSig:
 
     def append_to_multisig(self, private_key):
         """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+
         Appends a signature to multi signature
 
         Args:
@@ -1490,7 +1891,11 @@ class LogicSig:
             InvalidSecretKeyError: if no matching private key in multisig\
                 object
         """
-
+        warnings.warn(
+            "`append_to_multisig` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         if self.msig is None:
             raise error.InvalidSecretKeyError
         sig, index = LogicSig.single_sig_multisig(
@@ -1499,6 +1904,15 @@ class LogicSig:
         self.msig.subsigs[index].signature = base64.b64decode(sig)
 
     def __eq__(self, other):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`__eq__` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         if not isinstance(other, (LogicSig, future.transaction.LogicSig)):
             return False
         return (
@@ -1511,6 +1925,9 @@ class LogicSig:
 
 class LogicSigTransaction:
     """
+    NOTE: This class is deprecated:
+    Please use the v2 equivalent in `future.transaction` instead.
+
     Represents a logic signed transaction.
 
     Arguments:
@@ -1523,11 +1940,23 @@ class LogicSigTransaction:
     """
 
     def __init__(self, transaction, lsig):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`LogicSigTransaction` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         self.transaction = transaction
         self.lsig = lsig
 
     def verify(self):
         """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+
         Verify LogicSig against the transaction
 
         Returns:
@@ -1535,10 +1964,24 @@ class LogicSigTransaction:
                 the logic hash or the signature is valid against the sender\
                 address), false otherwise
         """
+        warnings.warn(
+            "`verify` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         public_key = encoding.decode_address(self.transaction.sender)
         return self.lsig.verify(public_key)
 
     def dictify(self):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`dictify` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         od = OrderedDict()
         if self.lsig:
             od["lsig"] = self.lsig.dictify()
@@ -1547,6 +1990,15 @@ class LogicSigTransaction:
 
     @staticmethod
     def undictify(d):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`undictify` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         lsig = None
         if "lsig" in d:
             lsig = LogicSig.undictify(d["lsig"])
@@ -1555,6 +2007,15 @@ class LogicSigTransaction:
         return lstx
 
     def __eq__(self, other):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`__eq__` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         if not isinstance(
             other,
             (LogicSigTransaction, future.transaction.LogicSigTransaction),
@@ -1567,6 +2028,9 @@ class LogicSigTransaction:
 
 def write_to_file(objs, path, overwrite=True):
     """
+    NOTE: This method is deprecated:
+    Please use the v2 equivalent in `future.transaction` instead.
+
     Write signed or unsigned transactions to a file.
 
     Args:
@@ -1590,7 +2054,11 @@ def write_to_file(objs, path, overwrite=True):
     Returns:
         bool: true if the transactions have been written to the file
     """
-
+    warnings.warn(
+        "`write_to_file` is a part of v1 `transaction` that is being deprecated. "
+        "Please use the v2 equivalent in `future.transaction` instead.",
+        DeprecationWarning,
+    )
     f = None
     if overwrite:
         f = open(path, "wb")
@@ -1613,6 +2081,9 @@ def write_to_file(objs, path, overwrite=True):
 
 def retrieve_from_file(path):
     """
+    NOTE: This method is deprecated:
+    Please use the v2 equivalent in `future.transaction` instead.
+
     Retrieve encoded objects from a file.
 
     Args:
@@ -1621,7 +2092,11 @@ def retrieve_from_file(path):
     Returns:
         Object[]: list of objects
     """
-
+    warnings.warn(
+        "`retrieve_from_file` is a part of v1 `transaction` that is being deprecated. "
+        "Please use the v2 equivalent in `future.transaction` instead.",
+        DeprecationWarning,
+    )
     f = open(path, "rb")
     objs = []
     unp = msgpack.Unpacker(f, raw=False)
@@ -1632,7 +2107,21 @@ def retrieve_from_file(path):
 
 
 class TxGroup:
+    """
+    NOTE: This class is deprecated:
+    Please use the v2 equivalent in `future.transaction` instead.
+    """
+
     def __init__(self, txns):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`TxGroup` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         assert isinstance(txns, list)
         """
         Transactions specifies a list of transactions that must appear
@@ -1645,18 +2134,39 @@ class TxGroup:
         self.transactions = txns
 
     def dictify(self):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`dictify` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         od = OrderedDict()
         od["txlist"] = self.transactions
         return od
 
     @staticmethod
     def undictify(d):
+        """
+        NOTE: This method is deprecated:
+        Please use the v2 equivalent in `future.transaction` instead.
+        """
+        warnings.warn(
+            "`undictify` is a part of v1 `transaction` that is being deprecated. "
+            "Please use the v2 equivalent in `future.transaction` instead.",
+            DeprecationWarning,
+        )
         txg = TxGroup(d["txlist"])
         return txg
 
 
 def calculate_group_id(txns):
     """
+    NOTE: This method is deprecated:
+    Please use the v2 equivalent in `future.transaction` instead.
+
     Calculate group id for a given list of unsigned transactions
 
     Args:
@@ -1665,6 +2175,11 @@ def calculate_group_id(txns):
     Returns:
         bytes: checksum value representing the group id
     """
+    warnings.warn(
+        "`calculate_group_id` is a part of v1 `transaction` that is being deprecated. "
+        "Please use the v2 equivalent in `future.transaction` instead.",
+        DeprecationWarning,
+    )
     if len(txns) > constants.tx_group_limit:
         raise error.TransactionGroupSizeError
     txids = []
@@ -1683,6 +2198,9 @@ def calculate_group_id(txns):
 
 def assign_group_id(txns, address=None):
     """
+    NOTE: This method is deprecated:
+    Please use the v2 equivalent in `future.transaction` instead.
+
     Assign group id to a given list of unsigned transactions.
 
     Args:
@@ -1693,6 +2211,11 @@ def assign_group_id(txns, address=None):
     Returns:
         txns (list): list of unsigned transactions with group property set
     """
+    warnings.warn(
+        "`assign_group_id` is a part of v1 `transaction` that is being deprecated. "
+        "Please use the v2 equivalent in `future.transaction` instead.",
+        DeprecationWarning,
+    )
     if len(txns) > constants.tx_group_limit:
         raise error.TransactionGroupSizeError
     gid = calculate_group_id(txns)


### PR DESCRIPTION
This PR adds deprecation warnings to v1 algod APIs and the old transaction format. In addition, there are warnings raised when the deprecated methods are called. 

The PR also adds a deprecation comment to `template` - previously, a similar comment was put in for `future.template`.

The `DeprecationWarning` that is added to this PR and the [langspec PR](https://github.com/algorand/py-algorand-sdk/pull/371/files) does trigger warnings on pytest (`pytest tests/unit_tests`). The corresponding tests should also be deleted when these features are removed from the SDK.

Related issue: https://github.com/algorand/algorand-sdk-testing/issues/218