### PR TITLE
Bug-fix: Implement `TransactionRejectedError`

### DIFF
--- a/algosdk/error.py
+++ b/algosdk/error.py
@@ -208,6 +208,8 @@ class IndexerHTTPError(Exception):
 class ConfirmationTimeoutError(Exception):
     pass
 
+class TransactionRejectedError(Exception):
+    pass
 
 class ABITypeError(Exception):
     def __init__(self, msg):

--- a/algosdk/error.py
+++ b/algosdk/error.py
@@ -208,8 +208,10 @@ class IndexerHTTPError(Exception):
 class ConfirmationTimeoutError(Exception):
     pass
 
+
 class TransactionRejectedError(Exception):
     pass
+
 
 class ABITypeError(Exception):
     def __init__(self, msg):


### PR DESCRIPTION
This PR implements the `TransactionRejectedError` which was referenced within the logic of the `wait_for_confirmation` method despite being undefined.

This is a small PR to quickly fix the issue at hand, however future work is necessary to ensure that this class of errors is caught moving forward.