### PR TITLE
Decoding: Fix roundtrip encode/decode tests for transactions

### DIFF
--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 # Configs for testing repo download:
 SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
-SDK_TESTING_BRANCH="master"
+SDK_TESTING_BRANCH="app-txn-decode"
 SDK_TESTING_HARNESS="test-harness"
 
 INSTALL_ONLY=0

--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 # Configs for testing repo download:
 SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
-SDK_TESTING_BRANCH="app-txn-decode"
+SDK_TESTING_BRANCH="master"
 SDK_TESTING_HARNESS="test-harness"
 
 INSTALL_ONLY=0

--- a/algosdk/box_reference.py
+++ b/algosdk/box_reference.py
@@ -29,7 +29,7 @@ class BoxReference:
         foreign_apps: List[int],
         this_app_id: int,
     ) -> "BoxReference":
-        # Check if references are already BoxReference typed
+        # Do not need to translate the references if they are already BoxReference type.
         if isinstance(ref, BoxReference):
             return ref
 

--- a/algosdk/box_reference.py
+++ b/algosdk/box_reference.py
@@ -23,10 +23,16 @@ class BoxReference:
 
     @staticmethod
     def translate_box_reference(
-        ref: Tuple[int, Union[bytes, bytearray, str, int]],
+        ref: Union[
+            Tuple[int, Union[bytes, bytearray, str, int]], "BoxReference"
+        ],
         foreign_apps: List[int],
         this_app_id: int,
     ) -> "BoxReference":
+        # Check if references are already BoxReference typed
+        if isinstance(ref, BoxReference):
+            return ref
+
         # Try checking reference id and name type.
         ref_id, ref_name = ref[0], encoding.encode_as_bytes(ref[1])
         if not isinstance(ref_id, int):

--- a/algosdk/future/transaction.py
+++ b/algosdk/future/transaction.py
@@ -1519,8 +1519,8 @@ class StateSchema:
     @staticmethod
     def undictify(d):
         return StateSchema(
-            num_uints=d["nui"] if "nui" in d else None,
-            num_byte_slices=d["nbs"] if "nbs" in d else None,
+            num_uints=d["nui"] if "nui" in d else 0,
+            num_byte_slices=d["nbs"] if "nbs" in d else 0,
         )
 
     def __eq__(self, other):
@@ -1628,13 +1628,13 @@ class ApplicationCallTxn(Transaction):
             self, sender, sp, note, lease, constants.appcall_txn, rekey_to
         )
         self.index = self.creatable_index(index)
-        self.on_complete = on_complete
+        self.on_complete = on_complete if on_complete else 0
         self.local_schema = self.state_schema(local_schema)
         self.global_schema = self.state_schema(global_schema)
         self.approval_program = self.teal_bytes(approval_program)
         self.clear_program = self.teal_bytes(clear_program)
         self.app_args = self.bytes_list(app_args)
-        self.accounts = accounts
+        self.accounts = accounts if accounts else None
         self.foreign_apps = self.int_list(foreign_apps)
         self.foreign_assets = self.int_list(foreign_assets)
         self.extra_pages = extra_pages


### PR DESCRIPTION
This PR changes how the `StateSchema` field, `accounts` field and `on_complete` fields are decoded. In addition, it makes a change to accept `BoxReferences` in addition to a list of app IDs and box names in `translate_box_reference()` (in the former case, no translation will be done). 

Related to https://github.com/algorand/algorand-sdk-testing/pull/248