### PR TITLE
Tests: Migrate v1 algod dependencies to v2 in cucumber tests

### DIFF
--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 # Configs for testing repo download:
 SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
-SDK_TESTING_BRANCH="master"
+SDK_TESTING_BRANCH="remove-v1-tests"
 SDK_TESTING_HARNESS="test-harness"
 
 INSTALL_ONLY=0

--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 # Configs for testing repo download:
 SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
-SDK_TESTING_BRANCH="remove-v1-tests"
+SDK_TESTING_BRANCH="master"
 SDK_TESTING_HARNESS="test-harness"
 
 INSTALL_ONLY=0

--- a/tests/steps/application_v2_steps.py
+++ b/tests/steps/application_v2_steps.py
@@ -446,14 +446,7 @@ def remember_app_id(context):
 @step("I wait for the transaction to be confirmed.")
 def wait_for_app_txn_confirm(context):
     wait_for_transaction_processing_to_complete_in_dev_mode()
-    if hasattr(context, "acl"):
-        # TODO: get rid of this branch of logic when v1 fully deprecated
-        assert "type" in context.acl.transaction_info(
-            context.transient_pk, context.app_txid
-        )
-        # assert "type" in context.acl.transaction_by_id(context.app_txid)
-    else:
-        transaction.wait_for_confirmation(context.app_acl, context.app_txid, 1)
+    transaction.wait_for_confirmation(context.app_acl, context.app_txid, 1)
 
 
 @given("an application id {app_id}")

--- a/tests/steps/application_v2_steps.py
+++ b/tests/steps/application_v2_steps.py
@@ -2,21 +2,14 @@ import base64
 import json
 import re
 import time
-import pytest
 
-from algosdk import (
-    abi,
-    atomic_transaction_composer,
-    encoding,
-    mnemonic,
-)
-from algosdk.abi.contract import NetworkInfo
-from algosdk.error import (
-    ABITypeError,
-    AtomicTransactionComposerError,
-)
-from algosdk.future import transaction
+import pytest
 from behave import given, step, then, when
+
+from algosdk import abi, atomic_transaction_composer, encoding, mnemonic
+from algosdk.abi.contract import NetworkInfo
+from algosdk.error import ABITypeError, AtomicTransactionComposerError
+from algosdk.future import transaction
 from tests.steps.other_v2_steps import read_program
 
 

--- a/tests/steps/other_v2_steps.py
+++ b/tests/steps/other_v2_steps.py
@@ -7,6 +7,10 @@ from pathlib import Path
 from urllib.request import Request, urlopen
 
 import parse
+from behave import register_type  # pylint: disable=no-name-in-module
+from behave import given, step, then, when
+from glom import glom
+
 from algosdk import dryrun_results, encoding, error, mnemonic, source_map
 from algosdk.error import AlgodHTTPError
 from algosdk.future import transaction
@@ -18,14 +22,6 @@ from algosdk.v2client.models import (
     DryrunRequest,
     DryrunSource,
 )
-from behave import (
-    given,
-    register_type,  # pylint: disable=no-name-in-module
-    step,
-    then,
-    when,
-)
-from glom import glom
 from tests.steps.steps import algod_port, indexer_port
 from tests.steps.steps import token as daemon_token
 

--- a/tests/steps/steps.py
+++ b/tests/steps/steps.py
@@ -483,11 +483,6 @@ def check_health(context):
     assert context.app_acl.health() == None
 
 
-@when("I get the suggested params")
-def suggested_params(context):
-    context.params = context.app_acl.suggested_params()
-
-
 @when("I create a bid")
 def create_bid(context):
     context.sk, pk = account.generate_account()
@@ -590,11 +585,6 @@ def convert_algos(context, microalgos):
 @then("it should still be the same amount of microalgos {microalgos}")
 def check_microalgos(context, microalgos):
     assert int(microalgos) == context.microalgos
-
-
-@then("I get account information")
-def acc_info(context):
-    context.app_acl.account_info(context.accounts[0])
 
 
 @then("I can get account information")

--- a/tests/steps/steps.py
+++ b/tests/steps/steps.py
@@ -259,12 +259,16 @@ def equal_msig_golden(context, golden):
 
 @when("I get versions with algod")
 def acl_v(context):
-    context.versions = context.acl.versions()["versions"]
+    context.versions = context.app_acl.versions()["versions"]
 
 
 @then("v1 should be in the versions")
 def v1_in_versions(context):
     assert "v1" in context.versions
+
+@then("v2 should be in the versions")
+def v2_in_versions(context):
+    assert "v2" in context.versions
 
 
 @when("I get versions with kmd")
@@ -527,7 +531,7 @@ def get_ledger(context):
 
 @then("the node should be healthy")
 def check_health(context):
-    assert context.acl.health() == None
+    assert context.app_acl.health() == None
 
 
 @when("I get the suggested params")

--- a/tests/steps/steps.py
+++ b/tests/steps/steps.py
@@ -779,7 +779,6 @@ def transfer_assets_to_creator(context, amount):
 @then("the creator should have {exp_balance} assets remaining")
 def check_asset_balance(context, exp_balance):
     asset_info_resp = context.app_acl.account_info(context.pk)["assets"]
-    asset_info = None
     for a in asset_info_resp:
         if a["asset-id"] == context.asset_index:
             assert a["amount"] == int(exp_balance)

--- a/tests/steps/steps.py
+++ b/tests/steps/steps.py
@@ -475,7 +475,7 @@ def sign_msig_both_equal(context):
 
 @then("I get the ledger supply")
 def get_ledger(context):
-    context.acl.ledger_supply()
+    context.app_acl.ledger_supply()
 
 
 @then("the node should be healthy")

--- a/tests/steps/steps.py
+++ b/tests/steps/steps.py
@@ -473,6 +473,11 @@ def sign_msig_both_equal(context):
     )
 
 
+@then("I get the ledger supply")
+def get_ledger(context):
+    context.acl.ledger_supply()
+
+
 @then("the node should be healthy")
 def check_health(context):
     assert context.app_acl.health() == None


### PR DESCRIPTION
Migrates algod v1 tests to use v2.

SDK Testing PR: https://github.com/algorand/algorand-sdk-testing/pull/249

In a future PR, it would be nice to refactor the `app_acl` to `aclv2` or even change it back to `acl` using the v2 client, as the name could be slightly confusing.