### PR TITLE
examples: Migrate v1 algod usage to v2 algod

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Next, create a wallet and an account:
 
 Visit the [Algorand dispenser](https://bank.testnet.algorand.network/) and enter the account address to fund your account.
 
-Next, in [tokens.py](https://github.com/algorand/py-algorand-sdk/blob/master/examples/tokens.py), either update the tokens and addresses, or provide a path to the data directory.
+Next, in [tokens.py](https://github.com/algorand/py-algorand-sdk/blob/master/examples/tokens.py), either update the tokens and addresses, or provide a path to the data directory. Alternatively, `tokens.py` also defaults to the sandbox harness configurations for algod and kmd, which can be brought up by running `make harness`.
 
 You're now ready to run example.py!
 

--- a/examples/custom_header_example.py
+++ b/examples/custom_header_example.py
@@ -5,7 +5,7 @@
 # key, instead of a string, as the token.
 
 import tokens
-from algosdk import algod
+from algosdk.v2client import algod
 
 headers = {
     "X-API-Key": "#######",

--- a/examples/custom_header_example.py
+++ b/examples/custom_header_example.py
@@ -37,7 +37,7 @@ def main():
         )
 
     # Retrieve latest block information
-    last_round = algod_client.status().get("lastRound")
+    last_round = algod_client.status().get("last-round")
     print("####################")
     block = algod_client.block_info(last_round)
     print(block)

--- a/examples/log_sig_example.py
+++ b/examples/log_sig_example.py
@@ -1,13 +1,14 @@
 # Example: creating a LogicSig transaction signed by a program that never approves the transfer.
 
 import tokens
-from algosdk import algod, account
+from algosdk import account
+from algosdk.v2client import algod
 from algosdk.future import transaction
 
 program = b"\x01\x20\x01\x00\x22"  # int 0
 lsig = transaction.LogicSigAccount(program)
 sender = lsig.address()
-receiver = account.generate_account()
+_, receiver = account.generate_account()
 
 # create an algod client
 acl = algod.AlgodClient(tokens.algod_token, tokens.algod_address)
@@ -25,4 +26,5 @@ lstx = transaction.LogicSigTransaction(txn, lsig)
 assert lstx.verify()
 
 # send them over network
+# Logicsig will reject the transaction
 acl.send_transaction(lstx)

--- a/examples/multisig_example.py
+++ b/examples/multisig_example.py
@@ -1,8 +1,10 @@
 # Example: manipulating multisig transactions
 
 import tokens
-from algosdk import account, algod, encoding
+
+from algosdk import account, encoding
 from algosdk.future import transaction
+from algosdk.v2client import algod
 
 # generate three accounts
 private_key_1, account_1 = account.generate_account()
@@ -16,7 +18,7 @@ msig = transaction.Multisig(version, threshold, [account_1, account_2])
 
 # get suggested parameters
 acl = algod.AlgodClient(tokens.algod_token, tokens.algod_address)
-suggested_params = acl.suggested_params_as_object()
+suggested_params = acl.suggested_params()
 
 # create a transaction
 sender = msig.address()

--- a/examples/notefield_example.py
+++ b/examples/notefield_example.py
@@ -3,10 +3,13 @@
 # with an auction bid. Note that you can put any bytes you want in the "note"
 # field; you don't have to use the NoteField object.
 
-import tokens
-from algosdk import algod, mnemonic, account, auction, constants, encoding
-from algosdk.future import transaction
 import base64
+
+import tokens
+
+from algosdk import account, auction, constants, encoding
+from algosdk.future import transaction
+from algosdk.v2client import algod
 
 acl = algod.AlgodClient(tokens.algod_token, tokens.algod_address)
 
@@ -14,7 +17,7 @@ acl = algod.AlgodClient(tokens.algod_token, tokens.algod_address)
 private_key, public_key = account.generate_account()
 
 # get suggested parameters
-sp = acl.suggested_params_as_object()
+sp = acl.suggested_params()
 
 # Set other parameters
 amount = 100000

--- a/examples/rekey_example.py
+++ b/examples/rekey_example.py
@@ -1,8 +1,10 @@
 # Example: rekeying
 
-from algosdk import account, algod
-from algosdk.future import transaction
 import tokens
+
+from algosdk import account
+from algosdk.future import transaction
+from algosdk.v2client import algod
 
 # this should be the current account
 sender_private_key, sender = account.generate_account()
@@ -12,7 +14,7 @@ amount = 0
 
 # get suggested parameters
 acl = algod.AlgodClient(tokens.algod_token, tokens.algod_address)
-suggested_params = acl.suggested_params_as_object()
+suggested_params = acl.suggested_params()
 
 # To rekey an account to a new address, add the `rekey_to` argument to creation.
 # After sending this rekeying transaction, every transaction needs to be signed by the private key of the new address

--- a/examples/tokens.py
+++ b/examples/tokens.py
@@ -1,22 +1,24 @@
-# examples helper file
+# Examples helper file
 
 from os import listdir
 from os.path import expanduser
 
 home = expanduser("~")
 
-# change these after starting the node and kmd
+# These values are initialized for the SDK sandbox harness.
+# You can bring the harness up by running `make harness`.
+# 
+# If you are using your own node installation, change these after starting the node and kmd.
 # algod info is in the algod.net and algod.token files in the data directory
 # kmd info is in the kmd.net and kmd.token files in the kmd directory in data
+kmd_token = "a" * 64
+kmd_address = "http://localhost:59999"
 
-kmd_token = ""
-kmd_address = ""
-
-algod_token = ""
-algod_address = ""
+algod_token = "a" * 64
+algod_address = "http://localhost:60000"
 
 # you can also get tokens and addresses automatically
-get_automatically = True
+get_automatically = False
 
 # path to the data directory
 data_dir_path = home + "/node/network/Node"

--- a/examples/tokens.py
+++ b/examples/tokens.py
@@ -7,7 +7,7 @@ home = expanduser("~")
 
 # These values are initialized for the SDK sandbox harness.
 # You can bring the harness up by running `make harness`.
-# 
+#
 # If you are using your own node installation, change these after starting the node and kmd.
 # algod info is in the algod.net and algod.token files in the data directory
 # kmd info is in the kmd.net and kmd.token files in the kmd directory in data

--- a/examples/transaction_group_example.py
+++ b/examples/transaction_group_example.py
@@ -1,8 +1,10 @@
 # Example: working with transaction groups
 
 import tokens
-from algosdk import algod, kmd, account
+
+from algosdk import account, kmd
 from algosdk.future import transaction
+from algosdk.v2client import algod
 
 # generate accounts
 private_key_sender, sender = account.generate_account()
@@ -13,7 +15,7 @@ acl = algod.AlgodClient(tokens.algod_token, tokens.algod_address)
 kcl = kmd.KMDClient(tokens.kmd_token, tokens.kmd_address)
 
 # get suggested parameters
-sp = acl.suggested_params_as_object()
+sp = acl.suggested_params()
 
 # create a transaction
 amount = 10000


### PR DESCRIPTION
This PR changes the `examples` to use the `v2client` instead of v1 algod. 

As a sanity check, ran the examples on my local machine. 