### PR TITLE
README: Delete Travis CI Badge 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # py-algorand-sdk
 
-[![Build Status](https://travis-ci.com/algorand/py-algorand-sdk.svg?branch=master)](https://travis-ci.com/algorand/py-algorand-sdk)
 [![PyPI version](https://badge.fury.io/py/py-algorand-sdk.svg)](https://badge.fury.io/py/py-algorand-sdk)
 [![Documentation Status](https://readthedocs.org/projects/py-algorand-sdk/badge/?version=latest&style=flat)](https://py-algorand-sdk.readthedocs.io/en/latest)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)


### PR DESCRIPTION
Since we do not use Travis CI badge anymore, this PR deletes the badge from the README.

Optionally, we could also add the Circle CI badge to our README: https://circleci.com/docs/status-badges/#generating-a-status-badge