### PR TITLE
Remove deprecated mnemonic.to_public_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# v2.0.0
+
+## What's Changed
+
+## Breaking changes
+* Removed `mnemonic.to_public_key` in favor of `account.address_from_private_key`.
+
 # v1.20.2
 
 ## What's Changed

--- a/algosdk/mnemonic.py
+++ b/algosdk/mnemonic.py
@@ -78,28 +78,6 @@ def to_private_key(mnemonic):
     return base64.b64encode(key.encode() + key.verify_key.encode()).decode()
 
 
-def to_public_key(mnemonic):
-    """
-    Return the public key for the mnemonic.
-    This method returns the Algorand address and will be deprecated, use
-    account.address_from_private_key instead.
-
-    Args:
-        mnemonic (str): mnemonic of the private key
-
-    Returns:
-        str: public key in base32
-    """
-    warnings.warn(
-        "to_public_key returns the Algorand address and will be "
-        "deprecated, use account.address_from_private_key instead",
-        DeprecationWarning,
-    )
-    key_bytes = _to_key(mnemonic)
-    key = signing.SigningKey(key_bytes)
-    return encoding.encode_address(key.verify_key.encode())
-
-
 def _from_key(key):
     """
     Return the mnemonic for the key.

--- a/tests/steps/account_v2_steps.py
+++ b/tests/steps/account_v2_steps.py
@@ -240,6 +240,7 @@ def parse_accounts_auth(context, roundNum, length, index, authAddr):
 
 @given('a signing account with address "{address}" and mnemonic "{mnemonic}"')
 def signing_account(context, address, mnemonic):
+    context.signing_address = address
     context.signing_mnemonic = mnemonic
 
 

--- a/tests/steps/application_v2_steps.py
+++ b/tests/steps/application_v2_steps.py
@@ -6,7 +6,7 @@ import time
 import pytest
 from behave import given, step, then, when
 
-from algosdk import abi, atomic_transaction_composer, encoding, mnemonic
+from algosdk import abi, account, atomic_transaction_composer, encoding, mnemonic
 from algosdk.abi.contract import NetworkInfo
 from algosdk.error import ABITypeError, AtomicTransactionComposerError
 from algosdk.future import transaction
@@ -632,7 +632,7 @@ def abi_method_adder(
     if account_type == "transient":
         sender = context.transient_pk
     elif account_type == "signing":
-        sender = mnemonic.to_public_key(context.signing_mnemonic)
+        sender = context.signing_address
     else:
         raise NotImplementedError(
             "cannot make transaction signer for " + account_type

--- a/tests/steps/application_v2_steps.py
+++ b/tests/steps/application_v2_steps.py
@@ -6,7 +6,13 @@ import time
 import pytest
 from behave import given, step, then, when
 
-from algosdk import abi, account, atomic_transaction_composer, encoding, mnemonic
+from algosdk import (
+    abi,
+    account,
+    atomic_transaction_composer,
+    encoding,
+    mnemonic,
+)
 from algosdk.abi.contract import NetworkInfo
 from algosdk.error import ABITypeError, AtomicTransactionComposerError
 from algosdk.future import transaction

--- a/tests/unit_tests/test_transaction.py
+++ b/tests/unit_tests/test_transaction.py
@@ -451,7 +451,7 @@ class TestPaymentTransaction(unittest.TestCase):
             "asure need above hundred"
         )
         sk = mnemonic.to_private_key(mn)
-        pk = mnemonic.to_public_key(mn)
+        pk = account.address_from_private_key(sk)
         fee = 1000
         gh = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
         votepk = "Kv7QI7chi1y6axoy+t7wzAVpePqRq/rkjzWh/RMYyLo="
@@ -493,7 +493,7 @@ class TestPaymentTransaction(unittest.TestCase):
             "asure need above hundred"
         )
         sk = mnemonic.to_private_key(mn)
-        pk = mnemonic.to_public_key(mn)
+        pk = account.address_from_private_key(sk)
         fee = 1000
         gh = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
         votepk = "Kv7QI7chi1y6axoy+t7wzAVpePqRq/rkjzWh/RMYyLo="
@@ -530,7 +530,8 @@ class TestPaymentTransaction(unittest.TestCase):
             "asure need above hundred"
         )
         sk = mnemonic.to_private_key(mn)
-        pk = mnemonic.to_public_key(mn)
+        pk = account.address_from_private_key(sk)
+
         fee = 1000
         gh = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
         votepk = "Kv7QI7chi1y6axoy+t7wzAVpePqRq/rkjzWh/RMYyLo="
@@ -563,7 +564,7 @@ class TestPaymentTransaction(unittest.TestCase):
             "measure need above hundred"
         )
         sk = mnemonic.to_private_key(mn)
-        pk = mnemonic.to_public_key(mn)
+        pk = account.address_from_private_key(sk)
         fee = 1000
         gh = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
 
@@ -610,7 +611,7 @@ class TestPaymentTransaction(unittest.TestCase):
             "measure need above hundred"
         )
         sk = mnemonic.to_private_key(mn)
-        pk = mnemonic.to_public_key(mn)
+        pk = account.address_from_private_key(sk)
         fee = 1000
         gh = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
 


### PR DESCRIPTION
Removes deprecated method `mnemonic.to_public_key` as part of v2.0.0 release.  https://github.com/algorand/py-algorand-sdk/pull/207 deprecated the method > 1 year ago.