### PR TITLE
Add remaining v2.0.0 breaking change CHANGELOG entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@
 
 ### Breaking Changes
 
-* Removed `mnemonic.to_public_key` in favor of `account.address_from_private_key`.
+* Removed v1 algod API (`algosdk/algod.py`) due to API end-of-life (2022-12-01).  Instead, use v2 algod API (`algosdk/v2client/algod.py`).
 * Removed `algosdk.future` package.  Moved package contents to `algosdk`.
 * Removed `encoding.future_msgpack_decode` method in favor of `encoding.msgpack_decode` method.
+* Removed `cost` field in `DryrunTxnResult` in favor of 2 fields:  `budget-added` and `budget-consumed`.  `cost` can be derived by `budget-consumed - budget-added`.
+* Removed `mnemonic.to_public_key` in favor of `account.address_from_private_key`.
 
 # v1.20.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Removed `encoding.future_msgpack_decode` method in favor of `encoding.msgpack_decode` method.
 * Removed `cost` field in `DryrunTxnResult` in favor of 2 fields:  `budget-added` and `budget-consumed`.  `cost` can be derived by `budget-consumed - budget-added`.
 * Removed `mnemonic.to_public_key` in favor of `account.address_from_private_key`.
+* Removed logicsig templates and `algosdk/data/langspec.json`.
 
 # v1.20.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Remove `encoding.future_msgpack_decode` method in favor of `encoding.msgpack_decode` method.
 * Remove `cost` field in `DryrunTxnResult` in favor of 2 fields:  `budget-added` and `budget-consumed`.  `cost` can be derived by `budget-consumed - budget-added`.
 * Remove `mnemonic.to_public_key` in favor of `account.address_from_private_key`.
-* Remove logicsig templates and `algosdk/data/langspec.json`.
+* Remove logicsig templates, `algosdk/data/langspec.json` and all methods in `logic` depending on it.
 
 # v1.20.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@
 
 ### Breaking Changes
 
-* Removed v1 algod API (`algosdk/algod.py`) due to API end-of-life (2022-12-01).  Instead, use v2 algod API (`algosdk/v2client/algod.py`).
-* Removed `algosdk.future` package.  Moved package contents to `algosdk`.
-* Removed `encoding.future_msgpack_decode` method in favor of `encoding.msgpack_decode` method.
-* Removed `cost` field in `DryrunTxnResult` in favor of 2 fields:  `budget-added` and `budget-consumed`.  `cost` can be derived by `budget-consumed - budget-added`.
-* Removed `mnemonic.to_public_key` in favor of `account.address_from_private_key`.
-* Removed logicsig templates and `algosdk/data/langspec.json`.
+* Remove v1 algod API (`algosdk/algod.py`) due to API end-of-life (2022-12-01).  Instead, use v2 algod API (`algosdk/v2client/algod.py`).
+* Remove `algosdk.future` package.  Move package contents to `algosdk`.
+* Remove `encoding.future_msgpack_decode` method in favor of `encoding.msgpack_decode` method.
+* Remove `cost` field in `DryrunTxnResult` in favor of 2 fields:  `budget-added` and `budget-consumed`.  `cost` can be derived by `budget-consumed - budget-added`.
+* Remove `mnemonic.to_public_key` in favor of `account.address_from_private_key`.
+* Remove logicsig templates and `algosdk/data/langspec.json`.
 
 # v1.20.2
 


### PR DESCRIPTION
Extends https://github.com/algorand/py-algorand-sdk/pull/415 with CHANGELOG entries for already merged breaking changes.  Upon merging the PR, the CHANGELOG _should_ be complete.