### PR TITLE
v2: Delete more references to `langspec`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
-include algosdk/data/langspec.json
 global-include *.pyi
 global-include *.typed

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,13 @@ setuptools.setup(
         "pycryptodomex>=3.6.0,<4",
         "msgpack>=1.0.0,<2",
     ],
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(
+        include=(
+            "algosdk",
+            # "algosdk.*",
+        )
+    ),
     python_requires=">=3.8",
-    package_data={"": ["data/langspec.json", "*.pyi", "py.typed"]},
+    package_data={"": ["*.pyi", "py.typed"]},
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,7 @@ setuptools.setup(
         "pycryptodomex>=3.6.0,<4",
         "msgpack>=1.0.0,<2",
     ],
-    packages=setuptools.find_packages(
-        include=(
-            "algosdk",
-            # "algosdk.*",
-        )
-    ),
+    packages=setuptools.find_packages(),
     python_requires=">=3.8",
     package_data={"": ["*.pyi", "py.typed"]},
     include_package_data=True,


### PR DESCRIPTION
This PR removes some extra references to`langspec.json`, which has been removed as of v2.x. 

#384 