### PR TITLE
Infrastructure: Add setup.py check to circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run: pip install -r requirements.txt
       - run: black --check .
       - run: mypy algosdk
-      - run: ! python setup.py check -s 2>&1 | tee /dev/tty | grep --quiet warning
+      - run: { ! python setup.py check -s 2>&1 | tee /dev/tty | grep --quiet warning }
       - run: pytest tests/unit_tests
   integration-test:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,8 @@ jobs:
       - run: black --check .
       - run: mypy algosdk
       - run: |
-          ! python setup.py check -s 2>&1 | tee /dev/tty | grep --quiet warning
+          python setup.py check -s
+          ! python setup.py check -s 2>&1 | tee /dev/tty | grep --quiet --ignore-case "warning"
       - run: pytest tests/unit_tests
   integration-test:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run: pip install -r requirements.txt
       - run: black --check .
       - run: mypy algosdk
-      - run: python setup.py check -s 2>&1 | tee /dev/tty | grep --quiet "warning"; test $? -eq 1
+      - run: python setup.py check -s 2>&1 | tee /dev/tty | {! grep --quiet "warning"}
       - run: pytest tests/unit_tests
   integration-test:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run: pip install -r requirements.txt
       - run: black --check .
       - run: mypy algosdk
-      - run: { ! python setup.py check -s 2>&1 | tee /dev/tty | grep --quiet warning }
+      - run: \! python setup.py check -s 2>&1 | tee /dev/tty | grep --quiet warning
       - run: pytest tests/unit_tests
   integration-test:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run: pip install -r requirements.txt
       - run: black --check .
       - run: mypy algosdk
-      - run: python setup.py check -s 2>&1 | tee /dev/tty | { grep --quiet "warning"; test $? -eq 1; }
+      - run: ! python setup.py check -s 2>&1 | tee /dev/tty | grep --quiet warning
       - run: pytest tests/unit_tests
   integration-test:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
       - run: pip install -r requirements.txt
       - run: black --check .
       - run: mypy algosdk
+      - run: python setup.py check --strict
       - run: pytest tests/unit_tests
   integration-test:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,8 @@ jobs:
       - run: pip install -r requirements.txt
       - run: black --check .
       - run: mypy algosdk
-      - run: \! python setup.py check -s 2>&1 | tee /dev/tty | grep --quiet warning
+      - run: |
+          ! python setup.py check -s 2>&1 | tee /dev/tty | grep --quiet warning
       - run: pytest tests/unit_tests
   integration-test:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - run: mypy algosdk
       - run: |
           python setup.py check -s
-          ! python setup.py check -s 2>&1 | tee /dev/tty | grep --quiet --ignore-case "warning"
+          ! python setup.py check -s 2>&1 | grep --quiet --ignore-case "warning"
       - run: pytest tests/unit_tests
   integration-test:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run: pip install -r requirements.txt
       - run: black --check .
       - run: mypy algosdk
-      - run: python setup.py check --strict
+      - run: python setup.py check -s 2>&1 | tee /dev/tty | grep --quiet "warning"; test $? -eq 1
       - run: pytest tests/unit_tests
   integration-test:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run: pip install -r requirements.txt
       - run: black --check .
       - run: mypy algosdk
-      - run: python setup.py check -s 2>&1 | tee /dev/tty | {! grep --quiet "warning"}
+      - run: python setup.py check -s 2>&1 | tee /dev/tty | { grep --quiet "warning"; test $? -eq 1; }
       - run: pytest tests/unit_tests
   integration-test:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - run: mypy algosdk
       - run: |
           python setup.py check -s
-          ! python setup.py check -s 2>&1 | grep --quiet --ignore-case "warning"
+          python setup.py check -s 2>&1 | (! grep -qEi 'error|warning')
       - run: pytest tests/unit_tests
   integration-test:
     parameters:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     description="Algorand SDK in Python",
     author="Algorand",
     author_email="pypiservice@algorand.com",
-    version="v1.20.2",
+    version="1.20.2",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/algorand/py-algorand-sdk",


### PR DESCRIPTION
This PR adds a check to see if `setup.py` is well-formed. It also removes the `v` prefix from the version, as it does not seem necessary [(related change)](https://github.com/algorand/py-algorand-sdk/commit/66660112154f85a17a5ccfd9ec36d28a6236dbbb#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R12) and generates a user warning: 
```
dist.py:487: UserWarning: Normalizing 'v1.20.2' to '1.20.2'
  warnings.warn(tmpl.format(**locals()))
```

Closes https://github.com/algorand/py-algorand-sdk/issues/409