### PR TITLE
Infrastructure: Only package `algosdk` in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,12 @@ setuptools.setup(
         "pycryptodomex>=3.6.0,<4",
         "msgpack>=1.0.0,<2",
     ],
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(
+        include=(
+            "algosdk",
+            "algosdk.*",
+        )
+    ),
     python_requires=">=3.8",
     package_data={"": ["*.pyi", "py.typed"]},
     include_package_data=True,


### PR DESCRIPTION
This PR fixes `setup.py` so only `algosdk` and its subdirectories are installed. 

Locally tested:
* Delete `*.egg-info` and `build` directories
* Run `pip install .`
* Check that only `algosdk` is included in the install in `site-packages`. `tests` and `examples` are no longer shipped with the installation, which may address #374 as well.

Closes #408 