### PR TITLE
Enhancement: Small Improvement for Interactively Overriding Local Testing Harness Env Vars 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,11 @@ workflows:
       - unit-test:
           matrix:
             parameters:
-              python-version: ["3.8", "3.9", "3.10"]
+              python-version: ["3.8", "3.9", "3.10", "3.11"]
       - integration-test:
           matrix:
             parameters:
-              python-version: ["3.8", "3.9", "3.10"]
+              python-version: ["3.8", "3.9", "3.10", "3.11"]
       - docset
 
 jobs:

--- a/.test-env
+++ b/.test-env
@@ -13,4 +13,23 @@ REMOVE_LOCAL_FEATURES=0
 
 # WARNING: Be careful when turning on the next variable.
 # In that case you'll need to provide all variables expected by `algorand-sdk-testing`'s `.env`
-OVERWRITE_TESTING_ENVIRONMENT=0
+OVERWRITE_TESTING_ENVIRONMENT=1
+
+# What can ease some of the pain above is to overwrite interactively:
+INTERACTIVE_TESTING_ENVIRONMENT=0
+
+ALGOD_CHANNEL=""
+ALGOD_URL="https://github.com/tzaffi/go-algorand"
+ALGOD_BRANCH="improve-some-goal-errors"
+ALGOD_SHA=""
+NETWORK=""
+NETWORK_TEMPLATE="images/algod/DevModeNetwork.json"
+NETWORK_BOOTSTRAP_URL=""
+NETWORK_GENESIS_FILE=""
+NETWORK_NUM_ROUNDS=30000
+NODE_ARCHIVAL="False"
+INDEXER_URL="https://github.com/algorand/indexer"
+INDEXER_BRANCH="develop"
+INDEXER_SHA=""
+INDEXER_DISABLED=""
+INDEXER_ENABLE_ALL_PARAMETERS="false"

--- a/.test-env
+++ b/.test-env
@@ -15,6 +15,9 @@ REMOVE_LOCAL_FEATURES=0
 # In that case you'll need to provide all variables expected by `algorand-sdk-testing`'s `.env`
 OVERWRITE_TESTING_ENVIRONMENT=1
 
+# WARNING: THE FOLLOWING IS FOR LOCAL DEVELOPMENT ONLY
+# IF SET TO 1 AND PUSHED TO C.I., THE TEST WILL HANG AND FAIL.
+#
 # What can ease some of the pain above is to overwrite interactively:
 INTERACTIVE_TESTING_ENVIRONMENT=0
 

--- a/.test-env
+++ b/.test-env
@@ -18,18 +18,39 @@ OVERWRITE_TESTING_ENVIRONMENT=1
 # What can ease some of the pain above is to overwrite interactively:
 INTERACTIVE_TESTING_ENVIRONMENT=0
 
-ALGOD_CHANNEL=""
-ALGOD_URL="https://github.com/tzaffi/go-algorand"
-ALGOD_BRANCH="improve-some-goal-errors"
+
+## --- FOR OVERWRITE PURPOSES
+
+# Used to determine sandbox build type:
+TYPE=source # (previously `"channel"`) #  OR "source"
+
+
+# Used when TYPE==channel:
+ALGOD_CHANNEL="nightly"
+
+# Used when TYPE==source:
+ALGOD_URL=https://github.com/tzaffi/go-algorand # (previously `"https://github.com/algorand/go-algorand"`)
+ALGOD_BRANCH=improve-some-goal-errors # (previously `"master"`)
 ALGOD_SHA=""
-NETWORK=""
-NETWORK_TEMPLATE="images/algod/DevModeNetwork.json"
-NETWORK_BOOTSTRAP_URL=""
-NETWORK_GENESIS_FILE=""
+
+# Used regardless of TYPE:
+NETWORK_TEMPLATE="images/algod/DevModeNetwork.json"  # refers to the ./images directory in the sandbox repo
 NETWORK_NUM_ROUNDS=30000
-NODE_ARCHIVAL="False"
 INDEXER_URL="https://github.com/algorand/indexer"
+NODE_ARCHIVAL="False"
 INDEXER_BRANCH="develop"
 INDEXER_SHA=""
-INDEXER_DISABLED=""
-INDEXER_ENABLE_ALL_PARAMETERS="false"
+
+# Sandbox configuration:
+SANDBOX_URL="https://github.com/algorand/sandbox"
+SANDBOX_BRANCH="master"
+LOCAL_SANDBOX_DIR=".sandbox"
+
+# replacement values for Sandbox's docker-compose:
+ALGOD_CONTAINER=sdk-harness-algod
+KMD_PORT=60001
+ALGOD_PORT=60000
+INDEXER_CONTAINER=sdk-harness-indexer
+INDEXER_PORT=59999
+POSTGRES_CONTAINER=sdk-harness-postgres
+POSTGRES_PORT=65432

--- a/.test-env
+++ b/.test-env
@@ -22,7 +22,7 @@ OVERWRITE_TESTING_ENVIRONMENT=1
 INTERACTIVE_TESTING_ENVIRONMENT=0
 
 
-## --- FOR OVERWRITE PURPOSES
+## --- FOR OVERWRITE PURPOSES! DELETE ALL THE BELOW!!!!
 
 # Used to determine sandbox build type:
 TYPE=source # (previously `"channel"`) #  OR "source"

--- a/harness_overwrite.py
+++ b/harness_overwrite.py
@@ -31,9 +31,11 @@ def overwrite(env_file: str, new_env: Dict[str, str]) -> None:
             if e := get_env(line):
                 key, old_val, extra = e
                 if key in new_env and (val := new_env[key]) != old_val:
-                    lines[i] = f"{key}={val} # (previously `{old_val}`)" + (
-                        f" # {extra}" if extra else ""
-                    ) + "\n"
+                    lines[i] = (
+                        f"{key}={val} # (previously `{old_val}`)"
+                        + (f" # {extra}" if extra else "")
+                        + "\n"
+                    )
 
         f.seek(0)
         f.writelines(lines)
@@ -52,8 +54,10 @@ def get_rewrites(
         and w != v
     }
 
+
 def get_keys(env: Dict[str, str]) -> Optional[str]:
-    print(f"""Which of the following env vars do you want to modify?
+    print(
+        f"""Which of the following env vars do you want to modify?
 
 {",".join(env.keys())}
 
@@ -61,8 +65,10 @@ def get_keys(env: Dict[str, str]) -> Optional[str]:
     
     A typical choice is:
 TYPE,ALGOD_URL,ALGOD_BRANCH
-""")
-    return input('CHOICES:\n').strip()
+"""
+    )
+    return input("CHOICES:\n").strip()
+
 
 def go():
     env_file = sys.argv[1]

--- a/harness_overwrite.py
+++ b/harness_overwrite.py
@@ -1,0 +1,84 @@
+import sys
+from typing import Dict, Optional, Tuple
+
+
+def get_env(line) -> Optional[Tuple[str, str, str]]:
+    if line and line[0] not in (" ", "#") and "=" in line:
+        key, others = line.split("=", maxsplit=1)
+        key = key.strip()
+        if "#" in others:
+            val, extra = others.split("#")
+            val = val.strip()
+        else:
+            val, extra = others.strip(), ""
+        return key, val, extra
+
+
+def manualy_parse(env_file: str) -> Dict[str, str]:
+    env = {}
+    with open(env_file) as f:
+        for line in f.readlines():
+            if e := get_env(line):
+                key, val, _ = e
+                env[key] = val
+    return env
+
+
+def overwrite(env_file: str, new_env: Dict[str, str]) -> None:
+    with open(env_file, "r+") as f:
+        lines = f.readlines()
+        for i, line in enumerate(lines):
+            if e := get_env(line):
+                key, old_val, extra = e
+                if key in new_env and (val := new_env[key]) != old_val:
+                    lines[i] = f"{key}={val} # (previously `{old_val}`)" + (
+                        f" # {extra}" if extra else ""
+                    ) + "\n"
+
+        f.seek(0)
+        f.writelines(lines)
+        f.truncate()
+
+
+def get_rewrites(
+    env: Dict[str, str], key_filter: Optional[str] = None
+) -> Dict[str, str]:
+    keys = key_filter.split(",") if key_filter else None
+    return {
+        k: w
+        for k, v in env.items()
+        if (not keys or k in keys)
+        and (w := input(f"{k} (default `{v}`):").strip())
+        and w != v
+    }
+
+def get_keys(env: Dict[str, str]) -> Optional[str]:
+    print(f"""Which of the following env vars do you want to modify?
+
+{",".join(env.keys())}
+
+    (skip for ALL, or provide comma separated)
+    
+    A typical choice is:
+TYPE,ALGOD_URL,ALGOD_BRANCH
+""")
+    return input('CHOICES:\n').strip()
+
+def go():
+    env_file = sys.argv[1]
+    env = manualy_parse(env_file)
+    print("_" * 50)
+    keys = get_keys(env)
+    print("_" * 50)
+    print("Please provide env variable overrides (skip to keep defaults)")
+    new_env = get_rewrites(env, key_filter=keys)
+
+    print("_" * 50)
+    print("OVERWRITING")
+    for k, v in new_env.items():
+        print(f"new_env[{k}]={v} (PREVIOUS: {env[k]=})")
+
+    overwrite(env_file, new_env)
+
+
+go()

--- a/harness_overwrite.py
+++ b/harness_overwrite.py
@@ -79,6 +79,7 @@ def go():
         print(f"new_env[{k}]={v} (PREVIOUS: {env[k]=})")
 
     overwrite(env_file, new_env)
+    print("_" * 50)
 
 
 go()

--- a/harness_overwrite.py
+++ b/harness_overwrite.py
@@ -82,7 +82,7 @@ def go():
     print("_" * 50)
     print("OVERWRITING")
     for k, v in new_env.items():
-        print(f"new_env[{k}]={v} (PREVIOUS: {env[k]=})")
+        print(f"new_env[{k}]={v} (PREVIOUS: env[{k}]={env[k]})")
 
     overwrite(env_file, new_env)
     print("_" * 50)

--- a/harness_overwrite.py
+++ b/harness_overwrite.py
@@ -2,7 +2,7 @@ import sys
 from typing import Dict, Optional, Tuple
 
 
-def get_env(line) -> Optional[Tuple[str, str, str]]:
+def get_env(line: str) -> Optional[Tuple[str, str, str]]:
     if line and line[0] not in (" ", "#") and "=" in line:
         key, others = line.split("=", maxsplit=1)
         key = key.strip()

--- a/harness_overwrite.py
+++ b/harness_overwrite.py
@@ -7,7 +7,7 @@ def get_env(line: str) -> Optional[Tuple[str, str, str]]:
         key, others = line.split("=", maxsplit=1)
         key = key.strip()
         if "#" in others:
-            val, extra = others.split("#")
+            val, extra = others.split("#", maxsplit=1)
             val = val.strip()
         else:
             val, extra = others.strip(), ""

--- a/test-harness.sh
+++ b/test-harness.sh
@@ -84,10 +84,12 @@ if [[ $OVERWRITE_TESTING_ENVIRONMENT == 1 ]]; then
   cp "$ENV_FILE" "$SDK_TESTING_HARNESS"/.env
 fi
 
+# **** BEGIN PYTHON ONLY **** #
 echo "$THIS: INTERACTIVE_TESTING_ENVIRONMENT=$INTERACTIVE_TESTING_ENVIRONMENT"
 if [[ $INTERACTIVE_TESTING_ENVIRONMENT == 1 ]]; then
   python harness_overwrite.py "$SDK_TESTING_HARNESS"/.env
 fi
+# **** END PYTHON ONLY **** #
 
 echo "$THIS: REMOVE_LOCAL_FEATURES=$REMOVE_LOCAL_FEATURES"
 ## Copy feature files into the project resources

--- a/test-harness.sh
+++ b/test-harness.sh
@@ -84,6 +84,10 @@ if [[ $OVERWRITE_TESTING_ENVIRONMENT == 1 ]]; then
   cp "$ENV_FILE" "$SDK_TESTING_HARNESS"/.env
 fi
 
+echo "$THIS: INTERACTIVE_TESTING_ENVIRONMENT=$INTERACTIVE_TESTING_ENVIRONMENT"
+if [[ $INTERACTIVE_TESTING_ENVIRONMENT == 1 ]]; then
+  python harness_overwrite.py "$SDK_TESTING_HARNESS"/.env
+fi
 
 echo "$THIS: REMOVE_LOCAL_FEATURES=$REMOVE_LOCAL_FEATURES"
 ## Copy feature files into the project resources


### PR DESCRIPTION
Should I keep these changes around and merge `harness_overwrite.py`? This tinkering work grew out of an investigation of the downstream effects of this go-algorand PR: https://github.com/algorand/go-algorand/pull/4951

### Arguments For and Against Merging the PR
- [ ] DO NOT MERGE
  - [ ] This violates the goal of keeping `up.sh` as similar as possible across all 4 SDK's
  - [ ] Even if we decide that this _should_ exist in all 4 SDK's, it's written in Python, and we can't impose installing Python across the other SDK's
  - [ ] It's not useful enough to justify the future maintenance costs
- [ ] MERGE
  - [ ] It's okay to have small "violations" of the uniformity goal, if there is a clear upside
  - [ ] Anything that eases the investigation of downstream implications for changes in `go-algorand` -_even a little_- is worthwhile
  - [ ] Python is so ubiquitous for shell scripting; we could impose requiring it in all the SDK's - imagine how much easier life would be if we could dispense with shell scripting in favor of python scripting?

## Q: What does `harness_overwrite.py` do?
It makes it slightly easier _locally_ to mod environments that the test harness needs.  In particular

1. set `INTERACTIVE_TESTING_ENVIRONMENT=1` in `.test-env`
2. run `make harness` and follow the prompts.

### here are what the prompts look like

```sh
Which of the following env vars do you want to modify?

VERBOSE_HARNESS,TYPE,ALGOD_CHANNEL,ALGOD_URL,ALGOD_BRANCH,ALGOD_SHA,NETWORK_TEMPLATE,NETWORK_NUM_ROUNDS,INDEXER_URL,NODE_ARCHIVAL,INDEXER_BRANCH,INDEXER_SHA,SANDBOX_URL,SANDBOX_BRANCH,LOCAL_SANDBOX_DIR,ALGOD_CONTAINER,KMD_PORT,ALGOD_PORT,INDEXER_CONTAINER,INDEXER_PORT,POSTGRES_CONTAINER,POSTGRES_PORT

    (skip for ALL, or provide comma separated)
    
    A typical choice is:
TYPE,ALGOD_URL,ALGOD_BRANCH

CHOICES:
```
Then I entered the "typical choice" and proceeded with the next prompts:
```
...

CHOICES:
TYPE,ALGOD_URL,ALGOD_BRANCH
__________________________________________________
Please provide env variable overrides (skip to keep defaults)
TYPE (default `"channel"`):source
ALGOD_URL (default `"https://github.com/algorand/go-algorand"`):https://github.com/tzaffi/go-algorand
ALGOD_BRANCH (default `"master"`):improve-some-goal-errors
__________________________________________________
OVERWRITING
new_env[TYPE]=source (PREVIOUS: env[TYPE]="channel")
new_env[ALGOD_URL]=https://github.com/tzaffi/go-algorand (PREVIOUS: env[ALGOD_URL]="https://github.com/algorand/go-algorand")
new_env[ALGOD_BRANCH]=improve-some-goal-errors (PREVIOUS: env[ALGOD_BRANCH]="master")
__________________________________________________
...
```

## Q: What are the implications for `harness_overwrite.py` in C.I.?

As long as one remembers not to merge in `INTERACTIVE_TESTING_ENVIRONMENT=1` in `.test-env`,
C.I. will continue running as before. In order to run the same override environment in C.I., you
need to take the following steps:

0. Follow the steps above to locally overwrite `test-harness/.env`
1. Copy the file portion in the resulting `.env` file starting from `TYPE=...` all the way to the end into `.test-env`
2. Make sure to set `INTERACTIVE_TESTING_ENVIRONMENT=0` and `OVERWRITE_TESTING_ENVIRONMENT=1`
3. Commit these changes and push to github

C.I. should now run against the new harness env variables.

