### PR TITLE
fix: remove unused positional argument "contract_type" from OverspecifiedRoundError and UnderspecifiedRoundError

### DIFF
--- a/algosdk/error.py
+++ b/algosdk/error.py
@@ -141,7 +141,7 @@ class EmptyAddressError(Exception):
 
 
 class OverspecifiedRoundError(Exception):
-    def __init__(self, contract_type):
+    def __init__(self):
         Exception.__init__(
             self,
             "Two arguments were given for the round "
@@ -150,7 +150,7 @@ class OverspecifiedRoundError(Exception):
 
 
 class UnderspecifiedRoundError(Exception):
-    def __init__(self, contract_type):
+    def __init__(self):
         Exception.__init__(self, "Please specify a round number")
 
 


### PR DESCRIPTION
Hi, Ori from the Foundation here.

I'm getting the following error when calling `AlgodClient.block_info(None)`
```
__init__() missing 1 required positional argument: 'contract_type'
```

Looked in the code and realized that both `OverspecifiedRoundError` and `UnderspecifiedRoundError` expect the unused positional argument `contract_type`. This PR fixes that.