### PR TITLE
Fix: improve SignedTransaction type signature for dryrun and send_transaction

### DIFF
--- a/algosdk/transaction.py
+++ b/algosdk/transaction.py
@@ -3233,9 +3233,7 @@ defaultAppId = 1380011588
 
 def create_dryrun(
     client: algod.AlgodClient,
-    txns: List[
-        Union[SignedTransaction, LogicSigTransaction, MultisigTransaction]
-    ],
+    txns: List["GenericSignedTransaction"],
     protocol_version=None,
     latest_timestamp=None,
     round=None,

--- a/algosdk/transaction.py
+++ b/algosdk/transaction.py
@@ -3233,7 +3233,9 @@ defaultAppId = 1380011588
 
 def create_dryrun(
     client: algod.AlgodClient,
-    txns: List[Union[SignedTransaction, LogicSigTransaction]],
+    txns: List[
+        Union[SignedTransaction, LogicSigTransaction, MultisigTransaction]
+    ],
     protocol_version=None,
     latest_timestamp=None,
     round=None,

--- a/algosdk/v2client/algod.py
+++ b/algosdk/v2client/algod.py
@@ -307,13 +307,13 @@ class AlgodClient:
         return self.algod_request("GET", req, **kwargs)
 
     def send_transaction(
-        self, txn: "transaction.Transaction", **kwargs: Any
+        self, txn: "transaction.GenericSignedTransaction", **kwargs: Any
     ) -> str:
         """
         Broadcast a signed transaction object to the network.
 
         Args:
-            txn (SignedTransaction or MultisigTransaction): transaction to send
+            txn (SignedTransaction, LogicSigTransaction, or MultisigTransaction): transaction to send
             request_header (dict, optional): additional header for request
 
         Returns:


### PR DESCRIPTION
Adds type parameter of GenericSignedTransaction to a couple places that had explicitly listed SignedTransaction types