### PR TITLE
tests: Increase funds in rekey account

### DIFF
--- a/tests/steps/steps.py
+++ b/tests/steps/steps.py
@@ -32,7 +32,7 @@ indexer_port = 59999
 algod_port = 60000
 kmd_port = 60001
 
-DEV_ACCOUNT_INITIAL_MICROALGOS: int = 10_000_000
+DEV_ACCOUNT_INITIAL_MICROALGOS: int = 100_000_000
 
 
 def wait_for_algod_transaction_processing_to_complete():


### PR DESCRIPTION
The `rekey` step creates a new wallet account, which may non-deterministically change the order of the accounts in the wallet (Ironically, we chose to create a [new wallet](https://github.com/algorand/algorand-sdk-testing/pull/212) account instead of rekeying an existing account due to non-deterministic test failures). This may affect how funds are transferred between a "rich" genesis account and another transient account. 

This PR just proposes to increase the amount transferred between transient accounts so fund transfers between the transient account and other accounts can happen more frequently before failing. Ideally, we can save the well-funded accounts in another way instead of relying on loading the accounts each time in the `wallet information` step. 