### PR TITLE
algod: Add endpoints for devmode timestamps, sync, and ready

### DIFF
--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 # Configs for testing repo download:
 SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
-SDK_TESTING_BRANCH="path-unit-tests"
+SDK_TESTING_BRANCH="master"
 SDK_TESTING_HARNESS="test-harness"
 
 INSTALL_ONLY=0

--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 # Configs for testing repo download:
 SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
-SDK_TESTING_BRANCH="timestamp-tests"
+SDK_TESTING_BRANCH="path-unit-tests"
 SDK_TESTING_HARNESS="test-harness"
 
 INSTALL_ONLY=0

--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 # Configs for testing repo download:
 SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
-SDK_TESTING_BRANCH="master"
+SDK_TESTING_BRANCH="timestamp-tests"
 SDK_TESTING_HARNESS="test-harness"
 
 INSTALL_ONLY=0

--- a/algosdk/atomic_transaction_composer.py
+++ b/algosdk/atomic_transaction_composer.py
@@ -270,7 +270,6 @@ class SimulateAtomicTransactionResponse:
     def __init__(
         self,
         version: int,
-        would_succeed: bool,
         failure_message: str,
         failed_at: Optional[List[int]],
         simulate_response: Dict[str, Any],
@@ -278,7 +277,6 @@ class SimulateAtomicTransactionResponse:
         results: List[SimulateABIResult],
     ) -> None:
         self.version = version
-        self.would_succeed = would_succeed
         self.failure_message = failure_message
         self.failed_at = failed_at
         self.simulate_response = simulate_response
@@ -760,7 +758,6 @@ class AtomicTransactionComposer:
 
         return SimulateAtomicTransactionResponse(
             version=simulation_result.get("version", 0),
-            would_succeed=simulation_result.get("would-succeed", False),
             failure_message=txn_group.get("failure-message", ""),
             failed_at=txn_group.get("failed-at"),
             simulate_response=simulation_result,

--- a/algosdk/constants.py
+++ b/algosdk/constants.py
@@ -9,7 +9,7 @@ ALGOD_AUTH_HEADER = "X-Algo-API-Token"
 """str: header key for algod requests"""
 INDEXER_AUTH_HEADER = "X-Indexer-API-Token"
 """str: header key for indexer requests"""
-UNVERSIONED_PATHS = ["/health", "/versions", "/metrics", "/genesis"]
+UNVERSIONED_PATHS = ["/health", "/versions", "/metrics", "/genesis", "/ready"]
 """str[]: paths that don't use the version path prefix"""
 NO_AUTH: List[str] = []
 """str[]: requests that don't require authentication"""

--- a/algosdk/v2client/algod.py
+++ b/algosdk/v2client/algod.py
@@ -646,6 +646,21 @@ class AlgodClient:
         )
         return self.simulate_transactions(request, **kwargs)
 
+    def get_ledger_state_delta(
+        self, round: int, **kwargs: Any
+    ) -> AlgodResponseType:
+        """
+        Get the state delta from the ledger.
+
+        Args:
+            round (int): State delta round
+
+        Returns:
+            Dict[str, Any]: Response from algod
+        """
+        req = f"/deltas/{round}"
+        return self.algod_request("GET", req, **kwargs)
+
     def get_sync_round(self, **kwargs: Any) -> AlgodResponseType:
         """
         Get the minimum sync round for the ledger.

--- a/algosdk/v2client/algod.py
+++ b/algosdk/v2client/algod.py
@@ -113,6 +113,8 @@ class AlgodClient:
             try:
                 return json.load(resp)
             except Exception as e:
+                if resp.status == 200:
+                    return {}
                 raise error.AlgodResponseError(
                     "Failed to parse JSON response from algod"
                 ) from e
@@ -640,6 +642,38 @@ class AlgodClient:
             ]
         )
         return self.simulate_transactions(request, **kwargs)
+
+    def get_timestamp_offset(
+        self,
+        **kwargs: Any,
+    ) -> AlgodResponseType:
+        """
+        Get the timestamp offset in block headers.
+        This feature is only available in dev mode networks.
+
+        Returns:
+            Dict[str, Any]: Response from algod
+        """
+        req = f"/devmode/blocks/offset"
+        return self.algod_request("GET", req, **kwargs)
+
+    def set_timestamp_offset(
+        self,
+        offset: int,
+        **kwargs: Any,
+    ) -> AlgodResponseType:
+        """
+        Set the timestamp offset in block headers.
+        This feature is only available in dev mode networks.
+
+        Args:
+            offset (int): Block timestamp offset
+
+        Returns:
+            Dict[str, Any]: Response from algod
+        """
+        req = f"/devmode/blocks/offset/{offset}"
+        return self.algod_request("POST", req, **kwargs)
 
 
 def _specify_round_string(

--- a/algosdk/v2client/algod.py
+++ b/algosdk/v2client/algod.py
@@ -113,6 +113,9 @@ class AlgodClient:
             try:
                 return json.load(resp)
             except Exception as e:
+                # Some algod responses currently return a 200 OK
+                # but have an empty response.
+                # Do not return an error, and just return an empty response.
                 if resp.status == 200:
                     return {}
                 raise error.AlgodResponseError(

--- a/algosdk/v2client/algod.py
+++ b/algosdk/v2client/algod.py
@@ -116,7 +116,7 @@ class AlgodClient:
                 # Some algod responses currently return a 200 OK
                 # but have an empty response.
                 # Do not return an error, and just return an empty response.
-                if resp.status == 200:
+                if resp.status == 200 and resp.length == 0:
                     return {}
                 raise error.AlgodResponseError(
                     "Failed to parse JSON response from algod"
@@ -645,21 +645,6 @@ class AlgodClient:
             ]
         )
         return self.simulate_transactions(request, **kwargs)
-
-    def get_ledger_state_delta(
-        self, round: int, **kwargs: Any
-    ) -> AlgodResponseType:
-        """
-        Get the state delta from the ledger.
-
-        Args:
-            round (int): State delta round
-
-        Returns:
-            Dict[str, Any]: Response from algod
-        """
-        req = f"/deltas/{round}"
-        return self.algod_request("GET", req, **kwargs)
 
     def get_sync_round(self, **kwargs: Any) -> AlgodResponseType:
         """

--- a/algosdk/v2client/algod.py
+++ b/algosdk/v2client/algod.py
@@ -646,10 +646,50 @@ class AlgodClient:
         )
         return self.simulate_transactions(request, **kwargs)
 
-    def get_timestamp_offset(
-        self,
-        **kwargs: Any,
-    ) -> AlgodResponseType:
+    def get_sync_round(self, **kwargs: Any) -> AlgodResponseType:
+        """
+        Get the minimum sync round for the ledger.
+
+        Returns:
+            Dict[str, Any]: Response from algod
+        """
+        req = "/ledger/sync"
+        return self.algod_request("GET", req, **kwargs)
+
+    def set_sync_round(self, round: int, **kwargs: Any) -> AlgodResponseType:
+        """
+        Set the minimum sync round for the ledger.
+
+        Args:
+            round (int): Sync round
+
+        Returns:
+            Dict[str, Any]: Response from algod
+        """
+        req = f"/ledger/sync/{round}"
+        return self.algod_request("GET", req, **kwargs)
+    
+    def unset_sync_round(self, **kwargs: Any) -> AlgodResponseType:
+        """
+        Unset the minimum sync round for the ledger.
+
+        Returns:
+            Dict[str, Any]: Response from algod
+        """
+        req = "/ledger/sync"
+        return self.algod_request("DELETE", req, **kwargs)
+
+    def ready(self, **kwargs: Any) -> AlgodResponseType:
+        """
+        Returns OK if the node is healthy and fully caught up.
+
+        Returns:
+            Dict[str, Any]: Response from algod
+        """
+        req = "/ready"
+        return self.algod_request("GET", req, **kwargs)
+
+    def get_timestamp_offset(self, **kwargs: Any) -> AlgodResponseType:
         """
         Get the timestamp offset in block headers.
         This feature is only available in dev mode networks.
@@ -657,7 +697,7 @@ class AlgodClient:
         Returns:
             Dict[str, Any]: Response from algod
         """
-        req = f"/devmode/blocks/offset"
+        req = "/devmode/blocks/offset"
         return self.algod_request("GET", req, **kwargs)
 
     def set_timestamp_offset(

--- a/algosdk/v2client/algod.py
+++ b/algosdk/v2client/algod.py
@@ -667,8 +667,8 @@ class AlgodClient:
             Dict[str, Any]: Response from algod
         """
         req = f"/ledger/sync/{round}"
-        return self.algod_request("GET", req, **kwargs)
-    
+        return self.algod_request("POST", req, **kwargs)
+
     def unset_sync_round(self, **kwargs: Any) -> AlgodResponseType:
         """
         Unset the minimum sync round for the ledger.

--- a/tests/environment.py
+++ b/tests/environment.py
@@ -53,6 +53,14 @@ class PathsHandler(http.server.SimpleHTTPRequestHandler):
         m = bytes(m, "ascii")
         self.wfile.write(m)
 
+    def do_DELETE(self):
+        self.send_response(200)
+        self.send_header("Content-type", "application/json")
+        self.end_headers()
+        m = json.dumps({"path": self.path})
+        m = bytes(m, "ascii")
+        self.wfile.write(m)
+
 
 def get_status_to_use():
     f = open("tests/features/resources/mock_response_status", "r")

--- a/tests/integration.tags
+++ b/tests/integration.tags
@@ -8,7 +8,6 @@
 @compile
 @compile.disassemble
 @compile.sourcemap
-@devmode.offset
 @dryrun
 @dryrun.testing
 @kmd

--- a/tests/integration.tags
+++ b/tests/integration.tags
@@ -14,4 +14,3 @@
 @rekey_v1
 @send
 @send.keyregtxn
-@simulate

--- a/tests/integration.tags
+++ b/tests/integration.tags
@@ -8,6 +8,7 @@
 @compile
 @compile.disassemble
 @compile.sourcemap
+@devmode.offset
 @dryrun
 @dryrun.testing
 @kmd

--- a/tests/steps/other_v2_steps.py
+++ b/tests/steps/other_v2_steps.py
@@ -905,6 +905,11 @@ def expect_path(context, path):
     assert exp_query == actual_query, f"{exp_query} != {actual_query}"
 
 
+@then('expect the request to be "{method}" "{path}"')
+def expect_request(context, method, path):
+    return expect_path(context, path)
+
+
 @then('expect error string to contain "{err:MaybeString}"')
 def expect_error(context, err):
     # TODO: this should actually do the claimed action
@@ -1498,6 +1503,31 @@ def check_missing_signatures(context, group, path):
             "missing-signature"
         ]
         assert missing_sig is True
+
+
+@when("we make a SetSyncRound call against round {round}")
+def set_sync_round_call(context, round):
+    context.response = context.acl.set_sync_round(round)
+
+
+@when("we make a GetSyncRound call")
+def get_sync_round_call(context):
+    context.response = context.acl.get_sync_round()
+
+
+@when("we make a UnsetSyncRound call")
+def unset_sync_round_call(context):
+    context.response = context.acl.unset_sync_round()
+
+
+@when("we make a SetBlockTimeStampOffset call against offset {offset}")
+def set_block_timestamp_offset(context, offset):
+    context.response = context.acl.set_timestamp_offset(offset)
+
+
+@when("we make a GetBlockTimeStampOffset call")
+def get_block_timestamp_offset(context):
+    context.response = context.acl.get_timestamp_offset()
 
 
 @when("I set the timestamp offset to be {offset}")

--- a/tests/steps/other_v2_steps.py
+++ b/tests/steps/other_v2_steps.py
@@ -1498,3 +1498,19 @@ def check_missing_signatures(context, group, path):
             "missing-signature"
         ]
         assert missing_sig is True
+
+
+@when("I set the timestamp offset to be {offset}")
+def set_timestamp_offset(context, offset):
+    context.app_acl.set_timestamp_offset(offset)
+
+
+@when("I get the timestamp offset")
+def get_timestamp_offset(context):
+    context.timestamp_offset = context.app_acl.get_timestamp_offset()
+
+
+@then("the timestamp offset should be {expected_offset}")
+def check_timestamp_offset(context, expected_offset):
+    actual_offset = context.timestamp_offset["offset"]
+    assert int(expected_offset) == actual_offset

--- a/tests/steps/other_v2_steps.py
+++ b/tests/steps/other_v2_steps.py
@@ -1520,6 +1520,11 @@ def unset_sync_round_call(context):
     context.response = context.acl.unset_sync_round()
 
 
+@when("we make a Ready call")
+def ready_call(context):
+    context.response = context.acl.ready()
+
+
 @when("we make a SetBlockTimeStampOffset call against offset {offset}")
 def set_block_timestamp_offset(context, offset):
     context.response = context.acl.set_timestamp_offset(offset)

--- a/tests/steps/other_v2_steps.py
+++ b/tests/steps/other_v2_steps.py
@@ -1538,19 +1538,3 @@ def set_block_timestamp_offset(context, offset):
 @when("we make a GetBlockTimeStampOffset call")
 def get_block_timestamp_offset(context):
     context.response = context.acl.get_timestamp_offset()
-
-
-@when("I set the timestamp offset to be {offset}")
-def set_timestamp_offset(context, offset):
-    context.app_acl.set_timestamp_offset(offset)
-
-
-@when("I get the timestamp offset")
-def get_timestamp_offset(context):
-    context.timestamp_offset = context.app_acl.get_timestamp_offset()
-
-
-@then("the timestamp offset should be {expected_offset}")
-def check_timestamp_offset(context, expected_offset):
-    actual_offset = context.timestamp_offset["offset"]
-    assert int(expected_offset) == actual_offset

--- a/tests/steps/other_v2_steps.py
+++ b/tests/steps/other_v2_steps.py
@@ -1505,6 +1505,11 @@ def check_missing_signatures(context, group, path):
         assert missing_sig is True
 
 
+@when("we make a GetLedgerStateDelta call against round {round}")
+def get_ledger_state_delta_call(context, round):
+    context.response = context.acl.get_ledger_state_delta(round)
+
+
 @when("we make a SetSyncRound call against round {round}")
 def set_sync_round_call(context, round):
     context.response = context.acl.set_sync_round(round)

--- a/tests/unit.tags
+++ b/tests/unit.tags
@@ -15,6 +15,7 @@
 @unit.indexer.logs
 @unit.offline
 @unit.program_sanity_check
+@unit.ready
 @unit.rekey
 @unit.responses
 @unit.responses.231

--- a/tests/unit.tags
+++ b/tests/unit.tags
@@ -20,9 +20,11 @@
 @unit.responses.231
 @unit.responses.blocksummary
 @unit.responses.participationupdates
+@unit.responses.timestamp
 @unit.responses.unlimited_assets
 @unit.sourcemap
 @unit.tealsign
+@unit.timestamp
 @unit.transactions
 @unit.transactions.keyreg
 @unit.transactions.payment

--- a/tests/unit.tags
+++ b/tests/unit.tags
@@ -21,10 +21,11 @@
 @unit.responses.231
 @unit.responses.blocksummary
 @unit.responses.participationupdates
+@unit.responses.sync
 @unit.responses.timestamp
 @unit.responses.unlimited_assets
 @unit.sourcemap
-@unit.statedelta
+@unit.sync
 @unit.tealsign
 @unit.timestamp
 @unit.transactions

--- a/tests/unit.tags
+++ b/tests/unit.tags
@@ -24,6 +24,7 @@
 @unit.responses.timestamp
 @unit.responses.unlimited_assets
 @unit.sourcemap
+@unit.statedelta
 @unit.tealsign
 @unit.timestamp
 @unit.transactions


### PR DESCRIPTION
This PR implements the devmode timestamp offset, sync, and ready endpoints in the Python SDK.

Tested locally and added some cucumber tests.