### PR TITLE
Enhancement: Adding `box_reference.py` to Read The Docs

### DIFF
--- a/docs/algosdk/box_reference.rst
+++ b/docs/algosdk/box_reference.rst
@@ -1,0 +1,7 @@
+box_reference
+=============
+
+.. automodule:: algosdk.box_reference
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/algosdk/index.rst
+++ b/docs/algosdk/index.rst
@@ -7,6 +7,7 @@ algosdk
    account
    atomic_transaction_composer
    auction
+   box_reference
    constants
    encoding
    error

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,4 +75,4 @@ html_sidebars = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# html_static_path = ["_static"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.abspath(".."))
 # -- Project information -----------------------------------------------------
 
 project = "algosdk"
-copyright = "2022 Algorand"
+copyright = "2023 Algorand"
 author = "Algorand"
 
 


### PR DESCRIPTION
## Box Reference was Missing from our Docs

This addresses a small portion of #419 .

### Testing
Verified locally that I was able to get the page:

<img width="1065" alt="image" src="https://github.com/algorand/py-algorand-sdk/assets/291133/385b7689-ddde-4ca9-97ac-ddd94166514d">
