### PR TITLE
other: Ignore formatting commits in git blame

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       python-version:
         type: string
     machine:
-     image: "ubuntu-2004:202104-01"
+     image: "ubuntu-2204:2022.04.2"
     steps:
       - checkout
       - run: PYTHON_VERSION=<< parameters.python-version >> make docker-test

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,5 +1,5 @@
 # .git-blame-ignore-revs
 # Exclude formatting commits made by black
-a9facdf30ca467b6e16d13ce88d8889bba7f2e1c
-ea81ba259216b8be7fb86ef5d3e9c151a94edf87
-81fe44f0dd9785b1665bbbea047aed591912534b
+a9facdf30ca467b6e16d13ce88d8889bba7f2e1c   # more black formatting Aug 17, 2021
+ea81ba259216b8be7fb86ef5d3e9c151a94edf87   # formatting Aug 16, 2021 
+81fe44f0dd9785b1665bbbea047aed591912534b   # apply black Aug 11, 2021

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,5 +1,8 @@
 # .git-blame-ignore-revs
 # Exclude formatting commits made by black
-a9facdf30ca467b6e16d13ce88d8889bba7f2e1c   # more black formatting Aug 17, 2021
-ea81ba259216b8be7fb86ef5d3e9c151a94edf87   # formatting Aug 16, 2021 
-81fe44f0dd9785b1665bbbea047aed591912534b   # apply black Aug 11, 2021
+# more black formatting Aug 17, 2021
+a9facdf30ca467b6e16d13ce88d8889bba7f2e1c
+# formatting Aug 16, 2021 
+ea81ba259216b8be7fb86ef5d3e9c151a94edf87
+# apply black Aug 11, 2021
+81fe44f0dd9785b1665bbbea047aed591912534b

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# .git-blame-ignore-revs
+# Exclude formatting commits made by black
+a9facdf30ca467b6e16d13ce88d8889bba7f2e1c
+ea81ba259216b8be7fb86ef5d3e9c151a94edf87
+81fe44f0dd9785b1665bbbea047aed591912534b


### PR DESCRIPTION
Adds a `.git-blame-ignore-revs` to exclude formatting commits in the git history. This makes it easier to trace the git blame from source code. To enable locally, you may have to edit your Git settings: `git config blame.ignoreRevsFile .git-blame-ignore-revs`.

Visually confirmed in the Github blame viewer on this branch - there are some occasional lines that slip through, but I think it's a problem with the UI.