### PR TITLE
CICD: Remove Reviewers

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -156,7 +156,7 @@ jobs:
         run: |
           echo -e "# ${RELEASE_TAG}\n\n${CHANGELOG_CONTENT}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREVIOUS_VERSION}...${RELEASE_TAG}" > msg_body.txt
           export msg_body=$(cat msg_body.txt)
-          # Note: There's an issue adding team reviewers, see https://github.com/cli/cli/issues/6395
+          # Note: There's an issue adding teams as reviewers, see https://github.com/cli/cli/issues/6395
           PULL_REQUEST_URL=$(gh pr create --base "master" \
             --title "FOR REVIEW ONLY: py-algorand-sdk $RELEASE_TAG" \
             --label "Skip-Release-Notes" \
@@ -172,7 +172,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.set-release.outputs.release-tag }}
         run: |
-          # Note: There's an issue adding team reviewers, see https://github.com/cli/cli/issues/6395
+          # Note: There's an issue adding teams as reviewers, see https://github.com/cli/cli/issues/6395
           PULL_REQUEST_URL=$(gh pr create --base "develop" \
             --title "FOR REVIEW ONLY: Merge back py-algorand-sdk $RELEASE_TAG to develop" \
             --label "Skip-Release-Notes" \

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -154,8 +154,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.set-release.outputs.release-tag }}
         run: |
-          echo -e "# ${RELEASE_TAG}\n\n${CHANGELOG_CONTENT}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREVIOUS_VERSION}...${RELEASE_TAG}" > msg_body.txt
-          export msg_body=$(cat msg_body.txt)
+          echo -e "# ${RELEASE_TAG}\n\n${CHANGELOG_CONTENT}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREVIOUS_VERSION}...${RELEASE_TAG}" > tmp_msg_body.txt
+          export msg_body=$(cat tmp_msg_body.txt)
+          rm tmp_msg_body.txt
           # Note: There's an issue adding teams as reviewers, see https://github.com/cli/cli/issues/6395
           PULL_REQUEST_URL=$(gh pr create --base "master" \
             --title "FOR REVIEW ONLY: py-algorand-sdk $RELEASE_TAG" \

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -154,7 +154,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.set-release.outputs.release-tag }}
         run: |
-          echo -e "# ${RELEASE_TAG}\n\n${CHANGELOG_CONTENT}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREVIOUS_VERSION}...${RELEASE_TAG}\ncc: @algorand/Scytale\n@algorand/devops" > msg_body.txt
+          echo -e "# ${RELEASE_TAG}\n\n${CHANGELOG_CONTENT}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREVIOUS_VERSION}...${RELEASE_TAG}\n\ncc: @algorand/scytale\n@algorand/devops" > msg_body.txt
           export msg_body=$(cat msg_body.txt)
           # Note: There's an issue adding teams as reviewers, see https://github.com/cli/cli/issues/6395
           PULL_REQUEST_URL=$(gh pr create --base "master" \
@@ -178,7 +178,7 @@ jobs:
             --label "Skip-Release-Notes" \
             --body "Merge back version changes to develop." | tail -n 1)
           echo "Pull request to Develop created: $PULL_REQUEST_URL"
-          DEVELOP_PR_MESSAGE="\nPull Request to develop: $PULL_REQUEST_URL\ncc: @algorand/Scytale\n@algorand/devops"
+          DEVELOP_PR_MESSAGE="\nPull Request to develop: $PULL_REQUEST_URL\n\ncc: @algorand/scytale\n@algorand/devops"
           echo "pull-request-develop-message=$DEVELOP_PR_MESSAGE" >> $GITHUB_ENV
 
       - name: Send Slack Message

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -156,6 +156,7 @@ jobs:
         run: |
           echo -e "# ${RELEASE_TAG}\n\n${CHANGELOG_CONTENT}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREVIOUS_VERSION}...${RELEASE_TAG}" > msg_body.txt
           export msg_body=$(cat msg_body.txt)
+          # Note: There's an issue adding team reviewers, see https://github.com/cli/cli/issues/6395
           PULL_REQUEST_URL=$(gh pr create --base "master" \
             --title "FOR REVIEW ONLY: py-algorand-sdk $RELEASE_TAG" \
             --label "Skip-Release-Notes" \
@@ -171,6 +172,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.set-release.outputs.release-tag }}
         run: |
+          # Note: There's an issue adding team reviewers, see https://github.com/cli/cli/issues/6395
           PULL_REQUEST_URL=$(gh pr create --base "develop" \
             --title "FOR REVIEW ONLY: Merge back py-algorand-sdk $RELEASE_TAG to develop" \
             --label "Skip-Release-Notes" \

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -176,7 +176,7 @@ jobs:
           PULL_REQUEST_URL=$(gh pr create --base "develop" \
             --title "FOR REVIEW ONLY: Merge back py-algorand-sdk $RELEASE_TAG to develop" \
             --label "Skip-Release-Notes" \
-            --reviewer algorand/scytale \
+            --reviewer algorand/Scytale \
             --reviewer algorand/devops \
             --body "Merge back version changes to develop." | tail -n 1)
           echo "Pull request to Develop created: $PULL_REQUEST_URL"

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -161,10 +161,15 @@ jobs:
             --title "FOR REVIEW ONLY: py-algorand-sdk $RELEASE_TAG" \
             --label "Skip-Release-Notes" \
             --body "$msg_body" | tail -n 1)
-          PULL_REQUEST_NUM=$(echo $PULL_REQUEST_URL | sed 's:.*/::')
-          echo "pull-request-master=$PULL_REQUEST_URL" >> $GITHUB_ENV
-          echo "pull-request-master-num=$PULL_REQUEST_NUM" >> $GITHUB_ENV
-          echo "Pull request to Master created: $PULL_REQUEST_URL"
+          if [[ $PULL_REQUEST_URL =~ ^https://github.com/${{ github.repository }}/pull/[0-9]+$ ]]; then
+            PULL_REQUEST_NUM=$(echo $PULL_REQUEST_URL | sed 's:.*/::')
+            echo "pull-request-master=$PULL_REQUEST_URL" >> $GITHUB_ENV
+            echo "pull-request-master-num=$PULL_REQUEST_NUM" >> $GITHUB_ENV
+            echo "Pull request to Master created: $PULL_REQUEST_URL"
+          else
+            echo "There was an issue creating the pull request to master branch."
+            exit 1
+          fi
 
       - name: Create Pull Request to Develop
         if: ${{ env.PRE_RELEASE_VERSION == '' }}
@@ -177,9 +182,14 @@ jobs:
             --title "FOR REVIEW ONLY: Merge back py-algorand-sdk $RELEASE_TAG to develop" \
             --label "Skip-Release-Notes" \
             --body "Merge back version changes to develop." | tail -n 1)
-          echo "Pull request to Develop created: $PULL_REQUEST_URL"
-          DEVELOP_PR_MESSAGE="\nPull Request to develop: $PULL_REQUEST_URL"
-          echo "pull-request-develop-message=$DEVELOP_PR_MESSAGE" >> $GITHUB_ENV
+          if [[ $PULL_REQUEST_URL =~ ^https://github.com/${{ github.repository }}/pull/[0-9]+$ ]]; then
+            echo "Pull request to Develop created: $PULL_REQUEST_URL"
+            DEVELOP_PR_MESSAGE="\nPull Request to develop: $PULL_REQUEST_URL"
+            echo "pull-request-develop-message=$DEVELOP_PR_MESSAGE" >> $GITHUB_ENV
+          else
+            echo "There was an issue creating the pull request to develop branch."
+            exit 1
+          fi
 
       - name: Send Slack Message
         id: slack

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -159,8 +159,6 @@ jobs:
           PULL_REQUEST_URL=$(gh pr create --base "master" \
             --title "FOR REVIEW ONLY: py-algorand-sdk $RELEASE_TAG" \
             --label "Skip-Release-Notes" \
-            --reviewer algorand/scytale \
-            --reviewer algorand/devops \
             --body "$msg_body" | tail -n 1)
           PULL_REQUEST_NUM=$(echo $PULL_REQUEST_URL | sed 's:.*/::')
           echo "pull-request-master=$PULL_REQUEST_URL" >> $GITHUB_ENV
@@ -176,8 +174,6 @@ jobs:
           PULL_REQUEST_URL=$(gh pr create --base "develop" \
             --title "FOR REVIEW ONLY: Merge back py-algorand-sdk $RELEASE_TAG to develop" \
             --label "Skip-Release-Notes" \
-            --reviewer algorand/Scytale \
-            --reviewer algorand/devops \
             --body "Merge back version changes to develop." | tail -n 1)
           echo "Pull request to Develop created: $PULL_REQUEST_URL"
           DEVELOP_PR_MESSAGE="\nPull Request to develop: $PULL_REQUEST_URL"

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -154,7 +154,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.set-release.outputs.release-tag }}
         run: |
-          echo -e "# ${RELEASE_TAG}\n\n${CHANGELOG_CONTENT}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREVIOUS_VERSION}...${RELEASE_TAG}" > msg_body.txt
+          echo -e "# ${RELEASE_TAG}\n\n${CHANGELOG_CONTENT}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREVIOUS_VERSION}...${RELEASE_TAG}\ncc: @algorand/Scytale\n@algorand/devops" > msg_body.txt
           export msg_body=$(cat msg_body.txt)
           # Note: There's an issue adding teams as reviewers, see https://github.com/cli/cli/issues/6395
           PULL_REQUEST_URL=$(gh pr create --base "master" \
@@ -178,7 +178,7 @@ jobs:
             --label "Skip-Release-Notes" \
             --body "Merge back version changes to develop." | tail -n 1)
           echo "Pull request to Develop created: $PULL_REQUEST_URL"
-          DEVELOP_PR_MESSAGE="\nPull Request to develop: $PULL_REQUEST_URL"
+          DEVELOP_PR_MESSAGE="\nPull Request to develop: $PULL_REQUEST_URL\ncc: @algorand/Scytale\n@algorand/devops"
           echo "pull-request-develop-message=$DEVELOP_PR_MESSAGE" >> $GITHUB_ENV
 
       - name: Send Slack Message

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -154,7 +154,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.set-release.outputs.release-tag }}
         run: |
-          echo -e "# ${RELEASE_TAG}\n\n${CHANGELOG_CONTENT}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREVIOUS_VERSION}...${RELEASE_TAG}\n\ncc: @algorand/scytale\n@algorand/devops" > msg_body.txt
+          echo -e "# ${RELEASE_TAG}\n\n${CHANGELOG_CONTENT}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREVIOUS_VERSION}...${RELEASE_TAG}" > msg_body.txt
           export msg_body=$(cat msg_body.txt)
           # Note: There's an issue adding teams as reviewers, see https://github.com/cli/cli/issues/6395
           PULL_REQUEST_URL=$(gh pr create --base "master" \
@@ -178,7 +178,7 @@ jobs:
             --label "Skip-Release-Notes" \
             --body "Merge back version changes to develop." | tail -n 1)
           echo "Pull request to Develop created: $PULL_REQUEST_URL"
-          DEVELOP_PR_MESSAGE="\nPull Request to develop: $PULL_REQUEST_URL\n\ncc: @algorand/scytale\n@algorand/devops"
+          DEVELOP_PR_MESSAGE="\nPull Request to develop: $PULL_REQUEST_URL"
           echo "pull-request-develop-message=$DEVELOP_PR_MESSAGE" >> $GITHUB_ENV
 
       - name: Send Slack Message


### PR DESCRIPTION
## Summary
Remove teams as reviewers. There seems to be unresolved issues with permissions for github actions to properly assign teams as reviewers: https://github.com/cli/cli/issues/6395

cc:
@algorand/devops 