### PR TITLE
CICD: Fix typos and add team label to release PR workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
         type: string
     machine:
      image: "ubuntu-2004:202104-01"
+    resource_class: large
     steps:
       - checkout
       - run: PYTHON_VERSION=<< parameters.python-version >> make docker-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,6 @@ jobs:
         type: string
     machine:
      image: "ubuntu-2004:202104-01"
-    resource_class: large
     steps:
       - checkout
       - run: PYTHON_VERSION=<< parameters.python-version >> make docker-test

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -43,7 +43,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -96,7 +96,7 @@ jobs:
                         ]
                     },
                     {
-                        "title": "## Enhancement",
+                        "title": "## Enhancements",
                         "labels": [
                             "Enhancement"
                         ]
@@ -122,7 +122,7 @@ jobs:
                     "on_property": "mergedAt"
                 },
                 "template": "#{{CHANGELOG}}",
-                "pr_template": "- #{{TITLE}} by #{{AUTHOR}} in ##{{NUMBER}}"
+                "pr_template": "- #{{TITLE}} by @#{{AUTHOR}} in ##{{NUMBER}}"
             }
 
       - name: Update Changelog
@@ -154,13 +154,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.set-release.outputs.release-tag }}
         run: |
-          echo -e "# ${RELEASE_TAG}\n\n${CHANGELOG_CONTENT}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREVIOUS_VERSION}...${RELEASE_TAG}" > tmp_msg_body.txt
+          echo -e "# What's Changed\n\n${CHANGELOG_CONTENT}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREVIOUS_VERSION}...${RELEASE_TAG}" > tmp_msg_body.txt
           export msg_body=$(cat tmp_msg_body.txt)
           rm tmp_msg_body.txt
           # Note: There's an issue adding teams as reviewers, see https://github.com/cli/cli/issues/6395
           PULL_REQUEST_URL=$(gh pr create --base "master" \
             --title "FOR REVIEW ONLY: py-algorand-sdk $RELEASE_TAG" \
             --label "Skip-Release-Notes" \
+            --label "Team Hyper Flow" \
             --body "$msg_body" | tail -n 1)
           if [[ $PULL_REQUEST_URL =~ ^https://github.com/${{ github.repository }}/pull/[0-9]+$ ]]; then
             PULL_REQUEST_NUM=$(echo $PULL_REQUEST_URL | sed 's:.*/::')
@@ -182,6 +183,7 @@ jobs:
           PULL_REQUEST_URL=$(gh pr create --base "develop" \
             --title "FOR REVIEW ONLY: Merge back py-algorand-sdk $RELEASE_TAG to develop" \
             --label "Skip-Release-Notes" \
+            --label "Team Hyper Flow" \
             --body "Merge back version changes to develop." | tail -n 1)
           if [[ $PULL_REQUEST_URL =~ ^https://github.com/${{ github.repository }}/pull/[0-9]+$ ]]; then
             echo "Pull request to Develop created: $PULL_REQUEST_URL"

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -134,7 +134,7 @@ jobs:
           echo "$(tail -n +2 CHANGELOG.md)" > CHANGELOG.md
           echo -e "# Changelog\n\n# ${RELEASE_VERSION}\n\n${CHANGELOG_CONTENT}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREVIOUS_VERSION}...${RELEASE_VERSION}" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
 
-      - name: Update version in setup.py
+      - name: Update Version in setup.py
         env:
           RELEASE_TAG: ${{ steps.set-release.outputs.release-tag }}
         run: |

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -159,7 +159,7 @@ jobs:
           rm tmp_msg_body.txt
           # Note: There's an issue adding teams as reviewers, see https://github.com/cli/cli/issues/6395
           PULL_REQUEST_URL=$(gh pr create --base "master" \
-            --title "FOR REVIEW ONLY: py-algorand-sdk $RELEASE_TAG" \
+            --title "FOR REVIEW ONLY: ${{ github.event.repository.name }} $RELEASE_TAG" \
             --label "Skip-Release-Notes" \
             --label "Team Hyper Flow" \
             --body "$msg_body" | tail -n 1)
@@ -181,7 +181,7 @@ jobs:
         run: |
           # Note: There's an issue adding teams as reviewers, see https://github.com/cli/cli/issues/6395
           PULL_REQUEST_URL=$(gh pr create --base "develop" \
-            --title "FOR REVIEW ONLY: Merge back py-algorand-sdk $RELEASE_TAG to develop" \
+            --title "FOR REVIEW ONLY: Merge back ${{ github.event.repository.name }} $RELEASE_TAG to develop" \
             --label "Skip-Release-Notes" \
             --label "Team Hyper Flow" \
             --body "Merge back version changes to develop." | tail -n 1)

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -78,52 +78,25 @@ jobs:
           fi
 
       - name: Build Changelog
-        uses: mikepenz/release-changelog-builder-action@v3.7.2
         id: build-changelog
         env:
           PREVIOUS_VERSION: ${{ steps.get-release.outputs.latest-tag }}
-        with:
-          fromTag: ${{ env.PREVIOUS_VERSION }}
-          toTag: ${{ env.RELEASE_BRANCH }}
-          failOnError: true
-          configurationJson: |
-            {
-                "categories": [
-                    {
-                        "title": "## New Features",
-                        "labels": [
-                            "New Feature"
-                        ]
-                    },
-                    {
-                        "title": "## Enhancements",
-                        "labels": [
-                            "Enhancement"
-                        ]
-                    },
-                    {
-                        "title": "## Bug Fixes",
-                        "labels": [
-                            "Bug-Fix"
-                        ]
-                    },
-                    {
-                        "title": "## Not Yet Enabled",
-                        "labels": [
-                            "Not-Yet-Enabled"
-                        ]
-                    }
-                ],
-                "ignore_labels": [
-                    "Skip-Release-Notes"
-                ],
-                "sort": {
-                    "order": "ASC",
-                    "on_property": "mergedAt"
-                },
-                "template": "#{{CHANGELOG}}",
-                "pr_template": "- #{{TITLE}} by @#{{AUTHOR}} in ##{{NUMBER}}"
-            }
+        run: |
+          CHANGELOG=$(curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/releases/generate-notes \
+            -d '{"tag_name":"${{ env.RELEASE_VERSION }}","target_commitish":"${{ env.RELEASE_BRANCH }}","previous_tag_name":"${{ env.PREVIOUS_VERSION }}","configuration_file_path":".github/release.yml"}' \
+            | jq -r '.body')
+
+          # The EOF steps are used to save multiline string in github:
+          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "changelog<<$EOF" >> $GITHUB_OUTPUT
+          echo -e "${CHANGELOG}" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
 
       - name: Update Changelog
         if: ${{ env.PRE_RELEASE_VERSION == '' }}
@@ -132,9 +105,9 @@ jobs:
           PREVIOUS_VERSION: ${{ steps.get-release.outputs.latest-tag }}
         run: |
           echo "$(tail -n +2 CHANGELOG.md)" > CHANGELOG.md
-          echo -e "# Changelog\n\n# ${RELEASE_VERSION}\n\n${CHANGELOG_CONTENT}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREVIOUS_VERSION}...${RELEASE_VERSION}" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
+          echo -e "# Changelog\n\n# ${RELEASE_VERSION}\n\n${CHANGELOG_CONTENT}" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
 
-      - name: Update Version in setup.py
+      - name: Update version in setup.py
         env:
           RELEASE_TAG: ${{ steps.set-release.outputs.release-tag }}
         run: |
@@ -154,15 +127,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.set-release.outputs.release-tag }}
         run: |
-          echo -e "# What's Changed\n\n${CHANGELOG_CONTENT}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREVIOUS_VERSION}...${RELEASE_TAG}" > tmp_msg_body.txt
-          export msg_body=$(cat tmp_msg_body.txt)
-          rm tmp_msg_body.txt
           # Note: There's an issue adding teams as reviewers, see https://github.com/cli/cli/issues/6395
           PULL_REQUEST_URL=$(gh pr create --base "master" \
             --title "FOR REVIEW ONLY: ${{ github.event.repository.name }} $RELEASE_TAG" \
             --label "Skip-Release-Notes" \
             --label "Team Hyper Flow" \
-            --body "$msg_body" | tail -n 1)
+            --body "${CHANGELOG_CONTENT}" | tail -n 1)
           if [[ $PULL_REQUEST_URL =~ ^https://github.com/${{ github.repository }}/pull/[0-9]+$ ]]; then
             PULL_REQUEST_NUM=$(echo $PULL_REQUEST_URL | sed 's:.*/::')
             echo "pull-request-master=$PULL_REQUEST_URL" >> $GITHUB_ENV

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -7,9 +7,9 @@ import sys
 
 
 def check_version(new_version):
-    if not re.fullmatch(r"[0-9]+\.[0-9]+\.[-a-z.0-9]+", new_version):
+    if not re.fullmatch(r"[0-9]+\.[0-9]+\.[a-z.0-9]+", new_version):
         sys.exit(
-            "The version does not match the regex(major.minor.patch): [0-9]+\.[0-9]+\.[-a-z.0-9]+"
+            "The version does not match the regex(major.minor.patch): [0-9]+\.[0-9]+\.[a-z.0-9]+"
         )
 
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -3,6 +3,14 @@
 
 import argparse
 import re
+import sys
+
+
+def check_version(new_version):
+    if not re.fullmatch(r"[0-9]+\.[0-9]+\.[-a-z.0-9]+", new_version):
+        sys.exit(
+            "The version does not match the regex(major.minor.patch): [0-9]+\.[0-9]+\.[-a-z.0-9]+"
+        )
 
 
 def bump_version(new_version, setup_py_path):
@@ -31,4 +39,5 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    check_version(args.new_version)
     bump_version(args.new_version, args.setup_py_path)


### PR DESCRIPTION
## Summary
After the previous release, noticed a few things to improve:
1. "Enhancement" sub-header should be "Enhancements" in the release notes
2. The `${RELEASE_TAG}` is redundant when you add a title to the release. Removing release tag here aligns with our previous releases.
3. Authors in the Release notes should be prefaced with a `@`
4. Add `Team Hyper Flow` to the PRs so we can easily track and make sure PRs get merged and not forgotten
5. Swap out the changelog-builder with github api

## Testing
Tested workflow in a separate repo.