### PR TITLE
Docs: Add missing pages for source map and dryrun results

### DIFF
--- a/docs/algosdk/dryrun_results.rst
+++ b/docs/algosdk/dryrun_results.rst
@@ -1,0 +1,7 @@
+dryrun_results
+==============
+
+.. automodule:: algosdk.dryrun_results
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/algosdk/index.rst
+++ b/docs/algosdk/index.rst
@@ -9,11 +9,13 @@ algosdk
    auction
    box_reference
    constants
+   dryrun_results
    encoding
    error
    kmd
    logic
    mnemonic
+   source_map
    transaction
    util
    v2client/index

--- a/docs/algosdk/source_map.rst
+++ b/docs/algosdk/source_map.rst
@@ -1,0 +1,7 @@
+source_map
+==========
+
+.. automodule:: algosdk.source_map
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
Add submodules that previously were missing from our docs.

To test, I generated the docs locally and confirmed this fixes the issue.