### PR TITLE
Fix typographic error when printing offline participation transaction

### DIFF
--- a/examples/participation.py
+++ b/examples/participation.py
@@ -40,5 +40,5 @@ offline_keyreg = transaction.KeyregTxn(
     votelst=None,
     votekd=None,
 )
-print(online_keyreg.dictify())
+print(offline_keyreg.dictify())
 # example: TRANSACTION_KEYREG_OFFLINE_CREATE


### PR DESCRIPTION
This fixes a typographical error when intending to print offline participation.