### PR TITLE
algod: Even in the face of urllib.error.HTTPError, return the json

### DIFF
--- a/algosdk/error.py
+++ b/algosdk/error.py
@@ -178,9 +178,10 @@ class AlgodRequestError(Exception):
 
 
 class AlgodHTTPError(Exception):
-    def __init__(self, msg, code=None):
+    def __init__(self, msg, code=None, data=None):
         super().__init__(msg)
         self.code = code
+        self.data = data
 
 
 class AlgodResponseError(Exception):

--- a/algosdk/v2client/algod.py
+++ b/algosdk/v2client/algod.py
@@ -105,10 +105,13 @@ class AlgodClient:
         except urllib.error.HTTPError as e:
             code = e.code
             es = e.read().decode("utf-8")
+            m = e  # If json.loads() fails, we'll return e itself
+            j = {}
             try:
-                e = json.loads(es)["message"]
+                j = json.loads(es)
+                m = j["message"]
             finally:
-                raise error.AlgodHTTPError(e, code)
+                raise error.AlgodHTTPError(m, code, j.get("data"))
         if response_format == "json":
             try:
                 return json.load(resp)

--- a/examples/inspect-error.py
+++ b/examples/inspect-error.py
@@ -1,0 +1,20 @@
+from algosdk import error, transaction
+
+from utils import get_algod_client, algod_env
+
+algod = get_algod_client(*algod_env())
+
+# This program is "#pragma version 5, +". It will fail because no arguments are on the stack.
+lsig = transaction.LogicSigAccount(b"\x05\x08")
+sender = lsig.address()
+# Get suggested parameters
+params = algod.suggested_params()
+
+amount = 10000
+txn = transaction.PaymentTxn(sender, params, sender, amount)
+lstx = transaction.LogicSigTransaction(txn, lsig)
+try:
+    txid = algod.send_transaction(lstx)
+    print("Impossible! Exception will have been thrown")
+except error.AlgodHTTPError as e:
+    print(e.data)

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -67,6 +67,23 @@ class SandboxAccount:
     signer: AccountTransactionSigner
 
 
+def algod_env():
+    algodata = os.environ.get("ALGORAND_DATA")
+    if not algodata:
+        return ()
+    try:
+        token = (
+            open(os.path.join(algodata, "algod.token"), "rt").read().strip()
+        )
+        net = (
+            "http://"
+            + open(os.path.join(algodata, "algod.net"), "rt").read().strip()
+        )
+        return (net, token)
+    except FileNotFoundError:
+        return ()
+
+
 def get_accounts(
     kmd_address: str = KMD_URL,
     kmd_token: str = KMD_TOKEN,


### PR DESCRIPTION
Previously, if we caught a urllib.error.HTTPError, we would try to parse the json response. If we succeeded we would return _only_ the `message` field of that response. If we failed, we're return the text of the response.  By "return" here, I actually mean "pack up into an Exception object and throw it".

Now, if succeed in parsing the response as json, we extend that exception object so that it also contains the JSON that we got. That way, client code can find extra goodies in the json["data"] field.

Also added a utility to the examples so they can be easily run against a locally running `algod`.