### PR TITLE
Simulate: Support newer simulate options

### DIFF
--- a/algosdk/atomic_transaction_composer.py
+++ b/algosdk/atomic_transaction_composer.py
@@ -272,11 +272,13 @@ class SimulateEvalOverrides:
         max_log_calls: Optional[int] = None,
         max_log_size: Optional[int] = None,
         allow_empty_signatures: Optional[bool] = None,
+        allow_unnamed_resources: Optional[bool] = None,
         extra_opcode_budget: Optional[int] = None,
     ) -> None:
         self.max_log_calls = max_log_calls
         self.max_log_size = max_log_size
         self.allow_empty_signatures = allow_empty_signatures
+        self.allow_unnamed_resources = allow_unnamed_resources
         self.extra_opcode_budget = extra_opcode_budget
 
     @staticmethod
@@ -296,6 +298,10 @@ class SimulateEvalOverrides:
         if "allow-empty-signatures" in eval_override_dict:
             eval_override.allow_empty_signatures = eval_override_dict[
                 "allow-empty-signatures"
+            ]
+        if "allow-unnamed-resources" in eval_override_dict:
+            eval_override.allow_unnamed_resources = eval_override_dict[
+                "allow-unnamed-resources"
             ]
         if "extra-opcode-budget" in eval_override_dict:
             eval_override.extra_opcode_budget = eval_override_dict[

--- a/algosdk/v2client/models/simulate_request.py
+++ b/algosdk/v2client/models/simulate_request.py
@@ -20,6 +20,7 @@ class SimulateTraceConfig:
     enable: bool
     stack_change: bool
     scratch_change: bool
+    state_change: bool
 
     def __init__(
         self,
@@ -27,16 +28,19 @@ class SimulateTraceConfig:
         enable: bool = False,
         stack_change: bool = False,
         scratch_change: bool = False,
+        state_change: bool = False,
     ) -> None:
         self.enable = enable
         self.stack_change = stack_change
         self.scratch_change = scratch_change
+        self.state_change = state_change
 
     def dictify(self) -> Dict[str, Any]:
         return {
             "enable": self.enable,
             "stack-change": self.stack_change,
             "scratch-change": self.scratch_change,
+            "state-change": self.state_change,
         }
 
     @staticmethod
@@ -45,6 +49,7 @@ class SimulateTraceConfig:
             enable="enable" in d and d["enable"],
             stack_change="stack-change" in d and d["stack-change"],
             scratch_change="scratch-change" in d and d["scratch-change"],
+            state_change="state-change" in d and d["state-change"],
         )
 
 
@@ -52,21 +57,27 @@ class SimulateRequest:
     txn_groups: List[SimulateRequestTransactionGroup]
     allow_more_logs: bool
     allow_empty_signatures: bool
+    allow_unnamed_resources: bool
     extra_opcode_budget: int
     exec_trace_config: SimulateTraceConfig
+    round: Optional[int]
 
     def __init__(
         self,
         *,
         txn_groups: List[SimulateRequestTransactionGroup],
+        round: Optional[int] = None,
         allow_more_logs: bool = False,
         allow_empty_signatures: bool = False,
+        allow_unnamed_resources: bool = False,
         extra_opcode_budget: int = 0,
         exec_trace_config: Optional[SimulateTraceConfig] = None,
     ) -> None:
         self.txn_groups = txn_groups
+        self.round = round
         self.allow_more_logs = allow_more_logs
         self.allow_empty_signatures = allow_empty_signatures
+        self.allow_unnamed_resources = allow_unnamed_resources
         self.extra_opcode_budget = extra_opcode_budget
         self.exec_trace_config = (
             exec_trace_config if exec_trace_config else SimulateTraceConfig()
@@ -77,7 +88,9 @@ class SimulateRequest:
             "txn-groups": [
                 txn_group.dictify() for txn_group in self.txn_groups
             ],
+            "round": self.round,
             "allow-more-logging": self.allow_more_logs,
+            "allow-unnamed-resources": self.allow_unnamed_resources,
             "allow-empty-signatures": self.allow_empty_signatures,
             "extra-opcode-budget": self.extra_opcode_budget,
             "exec-trace-config": self.exec_trace_config.dictify(),

--- a/tests/integration.tags
+++ b/tests/integration.tags
@@ -18,3 +18,4 @@
 @simulate.lift_log_limits
 @simulate.extra_opcode_budget
 @simulate.exec_trace_with_stack_scratch
+@simulate.exec_trace_with_state_change_and_hash

--- a/tests/steps/application_v2_steps.py
+++ b/tests/steps/application_v2_steps.py
@@ -701,7 +701,7 @@ def abi_method_adder(
             b"I should be unique thanks to this nonce: "
             + context.nonce.encode()
         )
-    
+
     boxes = None
     if comma_separated_boxes_string is not None:
         boxes = split_and_process_boxes(comma_separated_boxes_string)
@@ -747,7 +747,10 @@ def abi_method_adder(
         exception_key == "none"
     ), f"should have encountered an AtomicTransactionComposerError keyed by '{exception_key}', but no such exception has been detected"
 
-@when('I add a method call with the transient account, the current application, suggested params, on complete "{operation}", current transaction signer, current method arguments, boxes "{boxes}".')
+
+@when(
+    'I add a method call with the transient account, the current application, suggested params, on complete "{operation}", current transaction signer, current method arguments, boxes "{boxes}".'
+)
 def add_abi_method_call_with_boxes(context, operation, boxes):
     abi_method_adder(
         context,
@@ -755,6 +758,7 @@ def add_abi_method_call_with_boxes(context, operation, boxes):
         operation=operation,
         comma_separated_boxes_string=boxes,
     )
+
 
 @step(
     'I add a method call with the {account_type} account, the current application, suggested params, on complete "{operation}", current transaction signer, current method arguments; any resulting exception has key "{exception_key}".'

--- a/tests/steps/application_v2_steps.py
+++ b/tests/steps/application_v2_steps.py
@@ -24,6 +24,8 @@ def operation_string_to_enum(operation):
         return transaction.OnComplete.NoOpOC
     elif operation == "create":
         return transaction.OnComplete.NoOpOC
+    elif operation == "create-and-optin":
+        return transaction.OnComplete.OptInOC
     elif operation == "noop":
         return transaction.OnComplete.NoOpOC
     elif operation == "update":
@@ -359,7 +361,7 @@ def build_app_txn_with_transient(
         if (
             hasattr(context, "current_application_id")
             and context.current_application_id
-            and operation != "create"
+            and operation not in ("create", "create-and-optin")
         ):
             application_id = context.current_application_id
         operation = operation_string_to_enum(operation)
@@ -640,6 +642,7 @@ def add_nonce(context, nonce):
 
 def abi_method_adder(
     context,
+    *,
     account_type,
     operation,
     create_when_calling=False,
@@ -652,6 +655,7 @@ def abi_method_adder(
     extra_pages=None,
     force_unique_transactions=False,
     exception_key="none",
+    comma_separated_boxes_string=None,
 ):
     if account_type == "transient":
         sender = context.transient_pk
@@ -697,6 +701,10 @@ def abi_method_adder(
             b"I should be unique thanks to this nonce: "
             + context.nonce.encode()
         )
+    
+    boxes = None
+    if comma_separated_boxes_string is not None:
+        boxes = split_and_process_boxes(comma_separated_boxes_string)
 
     try:
         context.atomic_transaction_composer.add_method_call(
@@ -713,6 +721,7 @@ def abi_method_adder(
             clear_program=clear_program,
             extra_pages=extra_pages,
             note=note,
+            boxes=boxes,
         )
     except AtomicTransactionComposerError as atce:
         assert (
@@ -738,6 +747,14 @@ def abi_method_adder(
         exception_key == "none"
     ), f"should have encountered an AtomicTransactionComposerError keyed by '{exception_key}', but no such exception has been detected"
 
+@when('I add a method call with the transient account, the current application, suggested params, on complete "{operation}", current transaction signer, current method arguments, boxes "{boxes}".')
+def add_abi_method_call_with_boxes(context, operation, boxes):
+    abi_method_adder(
+        context,
+        account_type="transient",
+        operation=operation,
+        comma_separated_boxes_string=boxes,
+    )
 
 @step(
     'I add a method call with the {account_type} account, the current application, suggested params, on complete "{operation}", current transaction signer, current method arguments; any resulting exception has key "{exception_key}".'
@@ -747,8 +764,8 @@ def add_abi_method_call_with_exception(
 ):
     abi_method_adder(
         context,
-        account_type,
-        operation,
+        account_type=account_type,
+        operation=operation,
         exception_key=exception_key,
     )
 
@@ -759,8 +776,8 @@ def add_abi_method_call_with_exception(
 def add_abi_method_call(context, account_type, operation):
     abi_method_adder(
         context,
-        account_type,
-        operation,
+        account_type=account_type,
+        operation=operation,
     )
 
 
@@ -781,16 +798,16 @@ def add_abi_method_call_creation_with_allocs(
 ):
     abi_method_adder(
         context,
-        account_type,
-        operation,
-        True,
-        approval_program_path,
-        clear_program_path,
-        global_bytes,
-        global_ints,
-        local_bytes,
-        local_ints,
-        extra_pages,
+        account_type=account_type,
+        operation=operation,
+        create_when_calling=True,
+        approval_program_path=approval_program_path,
+        clear_program_path=clear_program_path,
+        global_bytes=global_bytes,
+        global_ints=global_ints,
+        local_bytes=local_bytes,
+        local_ints=local_ints,
+        extra_pages=extra_pages,
     )
 
 
@@ -806,11 +823,11 @@ def add_abi_method_call_creation(
 ):
     abi_method_adder(
         context,
-        account_type,
-        operation,
-        True,
-        approval_program_path,
-        clear_program_path,
+        account_type=account_type,
+        operation=operation,
+        create_when_calling=True,
+        approval_program_path=approval_program_path,
+        clear_program_path=clear_program_path,
     )
 
 
@@ -820,8 +837,8 @@ def add_abi_method_call_creation(
 def add_abi_method_call_nonced(context, account_type, operation):
     abi_method_adder(
         context,
-        account_type,
-        operation,
+        account_type=account_type,
+        operation=operation,
         force_unique_transactions=True,
     )
 

--- a/tests/steps/other_v2_steps.py
+++ b/tests/steps/other_v2_steps.py
@@ -1544,7 +1544,9 @@ def exec_trace_config_in_simulation(context, options: str):
     )
 
 
-def compare_avm_value_with_string_literal(expected_string_literal, actual_avm_value):
+def compare_avm_value_with_string_literal(
+    expected_string_literal, actual_avm_value
+):
     [expected_avm_type, expected_value] = expected_string_literal.split(":")
 
     if expected_avm_type == "uint64":
@@ -1639,6 +1641,7 @@ def exec_trace_unit_in_simulation_check_stack_scratch(
     else:
         assert len(scratch_var) == 0
 
+
 @then('the current application initial "{state_type}" state should be empty.')
 def current_app_initial_state_should_be_empty(context, state_type):
     assert context.atomic_transaction_composer_return
@@ -1648,7 +1651,9 @@ def current_app_initial_state_should_be_empty(context, state_type):
     )
 
     assert simulation_response["initial-states"]
-    app_initial_states = simulation_response["initial-states"]["app-initial-states"]
+    app_initial_states = simulation_response["initial-states"][
+        "app-initial-states"
+    ]
     assert app_initial_states
 
     initial_app_state = None
@@ -1670,8 +1675,12 @@ def current_app_initial_state_should_be_empty(context, state_type):
             raise Exception(f"Unknown state type: {state_type}")
 
 
-@then(u'the current application initial "{state_type}" state should contain "{key_str}" with value "{value_str}".')
-def current_app_initial_state_should_contain_key_value(context, state_type, key_str, value_str):
+@then(
+    'the current application initial "{state_type}" state should contain "{key_str}" with value "{value_str}".'
+)
+def current_app_initial_state_should_contain_key_value(
+    context, state_type, key_str, value_str
+):
     assert context.atomic_transaction_composer_return
     assert context.atomic_transaction_composer_return.simulate_response
     simulation_response = (
@@ -1679,7 +1688,9 @@ def current_app_initial_state_should_contain_key_value(context, state_type, key_
     )
 
     assert simulation_response["initial-states"]
-    app_initial_states = simulation_response["initial-states"]["app-initial-states"]
+    app_initial_states = simulation_response["initial-states"][
+        "app-initial-states"
+    ]
     assert app_initial_states
 
     initial_app_state = None
@@ -1726,11 +1737,21 @@ def current_app_initial_state_should_contain_key_value(context, state_type, key_
     assert actual_value is not None
     compare_avm_value_with_string_literal(value_str, actual_value)
 
-@then('{unit_index}th unit in the "{trace_type}" trace at txn-groups path "{txn_group_path}" should write to "{state_type}" state "{state_key}" with new value "{state_new_value}".')
-def trace_unit_should_write_to_state_with_value(context, unit_index, trace_type, txn_group_path, state_type, state_key, state_new_value):
+
+@then(
+    '{unit_index}th unit in the "{trace_type}" trace at txn-groups path "{txn_group_path}" should write to "{state_type}" state "{state_key}" with new value "{state_new_value}".'
+)
+def trace_unit_should_write_to_state_with_value(
+    context,
+    unit_index,
+    trace_type,
+    txn_group_path,
+    state_type,
+    state_key,
+    state_new_value,
+):
     def unit_finder(txn_group_path_str, trace_type, unit_index):
         pass
-
 
 
 """
@@ -1812,9 +1833,15 @@ def trace_unit_should_write_to_state_with_value(context, unit_index, trace_type,
   );
 """
 
-@then('"{trace_type}" hash at txn-groups path "{txn_group_path}" should be "{b64_hash}".')
-def program_hash_at_path_should_be(context, trace_type, txn_group_path, b64_hash):
+
+@then(
+    '"{trace_type}" hash at txn-groups path "{txn_group_path}" should be "{b64_hash}".'
+)
+def program_hash_at_path_should_be(
+    context, trace_type, txn_group_path, b64_hash
+):
     pass
+
 
 """
   Then(
@@ -1852,6 +1879,7 @@ def program_hash_at_path_should_be(context, trace_type, txn_group_path, b64_hash
     }
   );
 """
+
 
 @when("we make a SetSyncRound call against round {round}")
 def set_sync_round_call(context, round):

--- a/tests/steps/other_v2_steps.py
+++ b/tests/steps/other_v2_steps.py
@@ -1595,8 +1595,8 @@ def exec_trace_unit_in_simulation_check_stack_scratch(
     ]["exec-trace"]
     assert traces
 
-    for i in range(1, len(group_path)):
-        traces = traces["inner-trace"][group_path[i]]
+    for p in group_path[1:]:
+        traces = traces["inner-trace"][p]
         assert traces
 
     trace = []
@@ -1766,8 +1766,8 @@ def trace_unit_should_write_to_state_with_value(
         ]["exec-trace"]
         assert traces
 
-        for i in range(1, len(txn_group_path_split)):
-            traces = traces["inner-trace"][txn_group_path_split[i]]
+        for p in txn_group_path_split[1:]:
+            traces = traces["inner-trace"][p]
             assert traces
 
         trace = None
@@ -1839,8 +1839,8 @@ def program_hash_at_path_should_be(
     ]["exec-trace"]
     assert traces
 
-    for i in range(1, len(txn_group_path_split)):
-        traces = traces["inner-trace"][txn_group_path_split[i]]
+    for p in txn_group_path_split[1:]:
+        traces = traces["inner-trace"][p]
         assert traces
 
     hash = None


### PR DESCRIPTION
This SDK is behind on support for simulate options. This PR adds all simulate request options that are currently available in algod.

Similar to this JS PR: https://github.com/algorand/js-algorand-sdk/pull/818

Closes #519, closes #536