### PR TITLE
API: Support for header-only flag on /v2/block algod endpoint.

### DIFF
--- a/algosdk/v2client/algod.py
+++ b/algosdk/v2client/algod.py
@@ -270,6 +270,7 @@ class AlgodClient:
         block: Optional[int] = None,
         response_format: str = "json",
         round_num: Optional[int] = None,
+        header_only: Optional[bool] = None,
         **kwargs: Any,
     ) -> AlgodResponseType:
         """
@@ -280,8 +281,15 @@ class AlgodClient:
             response_format (str): the format in which the response is
                 returned: either "json" or "msgpack"
             round_num (int, optional): alias for block; specify one of these
+            header_only (bool, optional): if set to true, only block header would be
+                present in the the response
+
         """
         query = {"format": response_format}
+
+        if header_only:
+            query["header-only"] = "true"
+
         req = "/blocks/" + _specify_round_string(block, round_num)
         res = self.algod_request(
             "GET", req, query, response_format=response_format, **kwargs

--- a/tests/steps/other_v2_steps.py
+++ b/tests/steps/other_v2_steps.py
@@ -328,6 +328,19 @@ def block(context, block, response_format):
     )
 
 
+@when(
+    'we make a Get Block call for round {round} with format "{response_format}" and header-only "{header_only}"'
+)
+def block(context, round, response_format, header_only):
+    bool_opt = None
+    if header_only == "true":
+        bool_opt = True
+
+    context.response = context.acl.block_info(
+        int(round), response_format=response_format, header_only=bool_opt
+    )
+
+
 @when("we make any Get Block call")
 def block_any(context):
     context.response = context.acl.block_info(3, response_format="msgpack")
@@ -337,6 +350,17 @@ def block_any(context):
 def parse_block(context, pool):
     context.response = json.loads(context.response)
     assert context.response["block"]["rwd"] == pool
+
+
+@then(
+    'the parsed Get Block response should have rewards pool "{pool}" and no certificate or payset'
+)
+def parse_block_header(context, pool):
+    context.response = json.loads(context.response)
+    assert context.response["block"]["rwd"] == pool
+    assert (
+        "cert" not in context.response
+    ), f"Key 'cert' unexpectedly found in dictionary"
 
 
 @then(
@@ -654,7 +678,6 @@ def parse_txns_by_addr(context, roundNum, length, idx, sender):
     'we make a Lookup Block call against round {block:d} and header "{headerOnly:MaybeBool}"'
 )
 def lookup_block(context, block, headerOnly):
-    print("Header only = " + str(headerOnly))
     context.response = context.icl.block_info(
         block=block, header_only=headerOnly
     )


### PR DESCRIPTION
This PR adds support for a new header-only=true parameter to the '/v2/block/{round}' endpoint. Includes support for cross-SDK test cases.