### PR TITLE
Build: Update Box API Pagination-dependent integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       python-version:
         type: string
     machine:
-     image: "ubuntu-2004:2023.04.2"
+     image: "ubuntu-2404:2024.11.1"
     steps:
       - checkout
       - run: PYTHON_VERSION=<< parameters.python-version >> make docker-test


### PR DESCRIPTION
The pagination support on the Algod boxes endpoint depends solely on what box information has been persisted within algod. Previously, integration tests could assume once a transaction to add a box was approved, it was queryable. This PR introduces check and wait semantics to give ample time for the boxes to be made available via API.