### PR TITLE
fix: Wallet.delete_key() returns False for non-existent accounts

### DIFF
--- a/algosdk/wallet.py
+++ b/algosdk/wallet.py
@@ -149,9 +149,13 @@ class Wallet:
             address (str): base32 address of account to be deleted
 
         Returns:
-            bool: True if the account has been deleted
+            bool: True if the account has been deleted, False if the
+                account was not found in the wallet
         """
         self.automate_handle()
+        keys = self.kcl.list_keys(self.handle)
+        if address not in keys:
+            return False
         return self.kcl.delete_key(self.handle, self.pswd, address)
 
     def sign_transaction(self, txn):


### PR DESCRIPTION
## Bug Fix: Wallet.delete_key() always returns True

### Problem
`Wallet.delete_key()` always returns `True` even when the specified address doesn't exist in the wallet. This is because the underlying KMD API returns an empty dict for both successful deletions and non-existent keys.

### Solution
Check `list_keys()` before attempting deletion. If the address is not in the wallet's key list, return `False` immediately without making the API call.

### Changes
- `algosdk/wallet.py`: Added pre-check in `delete_key()` to return `False` for non-existent accounts. Updated docstring.

### Related
Closes #472