### PR TITLE
fix: Wallet.delete_key() returns False for non-existent addresses

### DIFF
--- a/algosdk/wallet.py
+++ b/algosdk/wallet.py
@@ -149,9 +149,12 @@ class Wallet:
             address (str): base32 address of account to be deleted
 
         Returns:
-            bool: True if the account has been deleted
+            bool: True if the account has been deleted, False if the
+                address was not found in the wallet
         """
         self.automate_handle()
+        if address not in self.list_keys():
+            return False
         return self.kcl.delete_key(self.handle, self.pswd, address)
 
     def sign_transaction(self, txn):


### PR DESCRIPTION
## Summary

`Wallet.delete_key()` always returns `True` regardless of whether the address exists in the wallet. Per the docs, it should return `True` only if the account was actually deleted, and `False` if the wallet doesn't contain the address.

## Root Cause

The KMD API's DELETE /key endpoint returns an empty response (`{}`) for both successful deletions and 'key not found' cases. The wallet layer was passing through this result without checking whether the address actually existed.

## Fix

Check if the address exists in the wallet via `list_keys()` before attempting deletion. Return `False` immediately if the address is not found.

## Testing

The fix can be verified with the reproduction case from the issue:

```python
from algosdk.wallet import Wallet
from beaker import sandbox

kmd_client = sandbox.kmd.get_client()
name, password = "foo", "bar"
kmd_client.create_wallet(name, password)
wallet = Wallet(name, password, kmd_client)

address = wallet.generate_key()
assert wallet.delete_key(address) == True   # key exists → True
assert wallet.delete_key(address) == False  # key gone → False
```

Fixes #472